### PR TITLE
Fixed liquid tag errors and broke images.

### DIFF
--- a/src/api-guides/tmc/itinerary-v1-guide.markdown
+++ b/src/api-guides/tmc/itinerary-v1-guide.markdown
@@ -609,13 +609,13 @@ BODY
 </Itinerary>
 ```
 
->**NOTE**: Submitting itinerary data with similar travel dates and trip data will result in multiple itineraries for the traveler if login_id is the only parameter used.
+**NOTE**: Submitting itinerary data with similar travel dates and trip data will result in multiple itineraries for the traveler if login_id is the only parameter used.
 
->**NOTE**: Store the returned TripID. This value is required for itinerary updates or cancellations.
+**NOTE**: Store the returned TripID. This value is required for itinerary updates or cancellations.
 
->**NOTE**: For additional itinerary samples, please contact your Platform Enablement PM.
+**NOTE**: For additional itinerary samples, please contact your Platform Enablement PM.
 
->**NOTE**: Store the concur-correlationid value returned in the header response for logging, troubleshooting, or case escalation purposes.
+**NOTE**: Store the concur-correlationid value returned in the header response for logging, troubleshooting, or case escalation purposes.
 
 ### Update an Itinerary
 

--- a/src/api-guides/tmc/profile-v2-guide.markdown
+++ b/src/api-guides/tmc/profile-v2-guide.markdown
@@ -101,7 +101,7 @@ The XSD (schema) for Profile API v2.0 is very similar to the existing schema for
 
 ### GET Profile Information
 
->**NOTE**: Our development organization has enforced the inclusion of the LastModifiedDate parameter. Users who omit LastModifiedDate, will receive an error. For users who would like to get profile summaries for all of their users, they can set LastModifiedDate to 1900-01-01T12:00:00.
+**NOTE**: Our development organization has enforced the inclusion of the LastModifiedDate parameter. Users who omit LastModifiedDate, will receive an error. For users who would like to get profile summaries for all of their users, they can set LastModifiedDate to 1900-01-01T12:00:00.
 
 #### Retrieve a List of Travel Profile Summaries by Last Modified Date (with Paging)
 

--- a/src/api-guides/tmc/tmc-overview.markdown
+++ b/src/api-guides/tmc/tmc-overview.markdown
@@ -339,14 +339,14 @@ Please have the following data and identifiers available:
 
 This is a screen shot of a typical Body response for retrieving a profile in POSTMAN.
 
-![Postman body response](images/overview-postman-body.png)
+![Postman body response](images/overview-postman-body.jpg)
 
 Select “Headers” for the response headers. Note “concur-correlationid”
 
 We require that you store the response GUID when an error occurs. When you log a case, please include the concur-correlationid GUID so we can retrieve the error(s) from our internal tools / logging system. This is what response headers look like in POSTMAN:
 
-![Postman response headers](images/overview-postman-headers.png)
+![Postman response headers](images/overview-postman-headers.jpg)
 
 Here’s what it would look like when we search for your application’s errors using the concur-correlationID GUID. It is vital for troubleshooting efficiency.
 
-![correlationID search results](images/overview-correlationid.png)
+![correlationID search results](images/overview-correlationid.jpg)


### PR DESCRIPTION
Updated and removed the additional ">" characters that were causing the liquid tag error and also fixed some broken images by swapping them out to their jpg correspondents vs png.

