### PR TITLE
TVR-13706 remove cash advance in Request v4 swagger

### DIFF
--- a/src/api-explorer/v4-0/ConcurRequest.swagger2.json
+++ b/src/api-explorer/v4-0/ConcurRequest.swagger2.json
@@ -27,10 +27,6 @@
     {
       "name": "Expected Expense Resource",
       "description": "Manage expected expenses attached to a Request"
-    },
-    {
-      "name": "Cash Advance Resource",
-      "description": "Retrieve cash advance for Concur Request"
     }
   ],
   "paths": {
@@ -729,7 +725,7 @@
           "Request Resource"
         ],
         "summary": "Get the list of comments for an existing Request",
-        "description": "Provides the list of comments for an existing Request (information displayed in the `comment`field of the Request header). Historization of comments is possible on the Request header. This endpoint will provide all the comments written during the life of the Request.",
+        "description": "Provides the list of comments for an existing Request (information displayed in the `comment` field of the Request header). Historization of comments is possible on the Request header. This endpoint will provide all the comments written during the life of the Request.",
         "operationId": "getCommentsByRequestUsingGET",
         "consumes": [
           "application/json"
@@ -806,122 +802,6 @@
           },
           "500": {
             "description": "Internal server error",
-            "examples": {
-              "application/json": {
-                "errors": [
-                  {
-                    "errorCode": "internalServerError",
-                    "errorMessage": "An unexpected error has prevented the operation"
-                  }
-                ]
-              }
-            },
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          },
-          "503": {
-            "description": "The service is currently unavailable",
-            "examples": {
-              "application/json": {
-                "errors": [
-                  {
-                    "errorCode": "entityOffline",
-                    "errorMessage": "Entity is offline, please try again later."
-                  }
-                ]
-              }
-            },
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          }
-        }
-      }
-    },
-    "/requests/{requestUuid}/cashadvances": {
-      "get": {
-        "tags": [
-          "Request Resource"
-        ],
-        "summary": "Get the list of cash advances assigned to an existing Request",
-        "description": "Provides the list of cash advances assigned to an existing Request.",
-        "operationId": "getCashAdvancesByRequestUsingGET",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "requestUuid",
-            "in": "path",
-            "description": "The unique identifier of the Request",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ResourceLink"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad param(s) : the request is invalid (user Id for this request has not been found, concur correlation id of the request is not a valid UUID, etc.) ",
-            "examples": {
-              "application/json": {
-                "errors": [
-                  {
-                    "errorCode": "userNotFound",
-                    "errorMessage": "User is not found."
-                  }
-                ]
-              }
-            },
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          },
-          "403": {
-            "description": "You do not have permission to perform this operation",
-            "examples": {
-              "application/json": {
-                "errors": [
-                  {
-                    "errorCode": "permissionDenied",
-                    "errorMessage": "Permission denied"
-                  }
-                ]
-              }
-            },
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          },
-          "404": {
-            "description": "Not found - You tried to get a non-existing request",
-            "examples": {
-              "application/json": {
-                "errors": [
-                  {
-                    "errorCode": "notFound",
-                    "errorMessage": "Resource not found"
-                  }
-                ]
-              }
-            },
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          },
-          "500": {
-            "description": "An unexpected error has prevented the operation",
             "examples": {
               "application/json": {
                 "errors": [
@@ -1857,7 +1737,7 @@
           "Expected Expense Resource"
         ],
         "summary": "Get the list of comments for an existing expected expense",
-        "description": "Provides the list of comments for an existing expected expense (information displayed in the `comment`field of the expected expense). Historization of comments is possible on an expected expense. This endpoint will provide all the comments written within an expected expense during the life of the Request.",
+        "description": "Provides the list of comments for an existing expected expense (information displayed in the `comment` field of the expected expense). Historization of comments is possible on an expected expense. This endpoint will provide all the comments written within an expected expense during the life of the Request.",
         "operationId": "getCommentsByExpenseUsingGET",
         "consumes": [
           "application/json"
@@ -2446,67 +2326,6 @@
         "name": {
           "type": "string",
           "description": "The approval status of the Request in the current user's language",
-          "minLength": 1,
-          "maxLength": 2147483647
-        }
-      }
-    },
-    "CashAdvance": {
-      "type": "object",
-      "properties": {
-        "amountRequested": {
-          "description": "The amount of the cash advance in the Request, expressed in the reimbursement currency of the employee at the time they created the cash advance",
-          "$ref": "#/definitions/Amount"
-        },
-        "approvalStatus": {
-          "description": "The approval status of the cash advance",
-          "$ref": "#/definitions/CashAdvanceApprovalStatus"
-        },
-        "cashAdvanceId": {
-          "type": "string",
-          "description": "The unique identifier of the cash advance"
-        },
-        "comment": {
-          "type": "string",
-          "description": "The last comment related to this cash advance"
-        },
-        "exchangeRate": {
-          "description": "The exchange rate that applies to the cash advance",
-          "$ref": "#/definitions/ExchangeRate"
-        },
-        "issueDate": {
-          "type": "string",
-          "description": "The date the cash advance was issued"
-        },
-        "requestDate": {
-          "type": "string",
-          "description": "The date the cash advance was submitted (last submit date in case of recall)"
-        }
-      }
-    },
-    "CashAdvanceApprovalStatus": {
-      "type": "object",
-      "properties": {
-        "code": {
-          "type": "string",
-          "description": "The code of the approval status of the cash advance",
-          "minLength": 1,
-          "maxLength": 2147483647,
-          "enum": [
-            "C_APPR",
-            "C_COMP",
-            "C_FILE",
-            "C_ISSU",
-            "C_NISU",
-            "C_NOTF",
-            "C_PECA",
-            "C_PEND",
-            "C_REJE"
-          ]
-        },
-        "name": {
-          "type": "string",
-          "description": "The approval status of the Cash Advance",
           "minLength": 1,
           "maxLength": 2147483647
         }


### PR DESCRIPTION
This documentation update is related to the migration to the Cash Advance v4 API (GA end of September) with a new read scope available end of October
- Cash advance resource tag removed
- Removal of Cash Advance endpoint (Get the detail of an existing cash advance) section
- Removal of cash advance object section