### PR TITLE
Update v2.profile-resource.markdown

### DIFF
--- a/src/api-reference/travel-profile/v2.profile-resource.markdown
+++ b/src/api-reference/travel-profile/v2.profile-resource.markdown
@@ -257,8 +257,8 @@ Name|Data Type|Description|Update|Create|Comments
 `CountryCode`|`string`|The country code in from the [ISO 3166-1 alpha-2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) specification. Format: Char(2)|-|-|-
 `PhoneNumber`|`string`|The phone number as entered by the user, which may contain characters such as () or -. For CellPhone, Number may only contain digits, dashes, parenthesis, and spaces. Format: nvarchar(60) <br>|required (Cell)|required (Cell)|Required for Cell types.
 `Extension`|`string`|The phone extension. Format: nvarchar(60)|-|-|-
-`MobileDevice`|`string`|The OS of the mobile device. Values are:<br> Android Phone<br> Android Tablet<br> Blackberry<br> iOS Phone<br> iOS Tablet<br> Not a smartphone<br> Other iOS device<br> Other smartphone<br> Unknown<br> Window Mobile|-|-|-
-`MobileName`|`string`|The name the user assigned to the mobile device. Format: nvarchar(255)|-|-|-
+`MobileDevice`|`string`|This is deprecated as of December 2021 and will no longer be returned|-|-|-
+`MobileName`|`string`|This is deprecated as of December 2021 and will no longer be returned|-|-|-
 
 **NOTES**
 
@@ -284,8 +284,8 @@ Name|Data Type|Description|Update|Create|Comments
 `StateProvince`|`string`|The state or province. Format: nvarchar(30)|-|-|-
 `CountryCode`|`string`|The country code in from the [ISO 3166-1 alpha-2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) specification. Format: char(2)|-|-|-
 `PostalCode`|`string`|The postal code. Format: nvarchar(20)|-|-|-
-`Longitude`|`string`|Longitude value of Work Address.|Cannot Update|-|-
-`Latitude`|`string`|Latitude value of Work Address.|Cannot Update|-|-
+`Longitude`|`string`|Deprecated as of December 2021 and will no longer be returned|Cannot Update|-|-
+`Latitude`|`string`|Deprecated as of December 2021 and will no longer be returned|Cannot Update|-|-
 
 #### <a name="schema-NationalIDs"></a>NationalIDs
 


### PR DESCRIPTION
Added "deprecated" message to fields that will no longer be available in the API. This was announced in the Nov 2021 release notes as a "Planned" change.

