### PR TITLE
TVR-14212 [Request ESS] Documentation update

### DIFF
--- a/src/event-topics/request/v4.request-events.md
+++ b/src/event-topics/request/v4.request-events.md
@@ -74,6 +74,7 @@ Name|Type|Format|Description
 `recipientId`|`string`|-|Unique identifier of the user to whom the Request is pending approval. This is not displayed if the Request is, for example, approved or pending a generic step such as TMC step.
 `isClosed`|`boolean`|`true`/`false`|If `true`, the Request is at the CLOSED status.
 `isTest`|`boolean`|`true`/`false`|If `true`, the user is a test user.
+`isRecall`|`boolean`|`true`/`false`|Is `true` only if the Request is at the SENDBACK status related to a recalled action from the traveler/delegate.
 `status`|`string`|`enum`|Approved: `APPROVED` <br>Canceled: `CANCELED` <br>Sent Back / Recalled: `SENTBACK` <br>Pending TMC agent: `PendingTMCApproval` <br>Pending Request Manager: `PendingRequestManagerApproval` <br>Request Auditor: `PendingRequestAuditorApproval` <br>Pending Cost Object Approver: `PendingCostObjectApproverApproval` <br>Pending Authorized Approver: `PendingAuthorizedApproverApproval` <br>Pending Budget approver/manager: `PendingBudgetManagerApproval` <br>Pending Risk Manager: `PendingRiskManagerApproval` <br>Pending Request Administrator: `PendingRequestAdministratorApproval` <br>Pending External validation: `PendingExternalValidation`
 `stepCode`|`String`|`enum`|Code provided by the admin that the client can use to differentiate between the steps. <br>Request Submit: if the target step (the next workflow step that the request stops at) is not configured for notifications, then step code will be `NULL`. <br>Request Send Back or Request Recall - `SENDBACK` <br>Legacy External validation post submit - `EXTVAL` <br>Legacy External validation pre-extract - `EXTVAL` <br>All other cases code step code as configured by admin in workflow configuration will be populated.
 `entityId`|`String`|`alphanumeric`|Unique Identifier of the Concur Entity. A valid EntityID pattern is [pdt][a-zA-Z0-9] {5,31}. It starts with p - production / d - demo/ t- test. It consists of a-zA-Z0-9 with length at least 5 but no more than 31 characters.
@@ -93,6 +94,7 @@ Name|Type|Format|Description
         "companyId": "cef1dee9-c4d9-4bd0-9237-01a3978bfda4",
         "isClosed": "false",
         "isTest": "false",
+        "isRecall”: "false",
         "recipientId": "55b671dd-ee55-4817-a228-90f5077ec61c",
         "requestId": "LLU9",
         "actingUserId": "ee4a3a2a-2f7a-482c-abd6-82435c9b20c4",
@@ -119,6 +121,7 @@ Name|Type|Format|Description
         "companyId": "39d88963-dd68-4be2-9a2d-b5843e6247bd",
         "isClosed": "false",
         "isTest": "false",
+        "isRecall”: "false",
         "requestId": "CN4T",
         "actingUserId": "55b671dd-ee55-4817-a228-90f5077ec61c",
         "id": "E1D6A41596D5B04F87F991E66CFBD3F9",
@@ -144,6 +147,7 @@ Name|Type|Format|Description
         "companyId": "39d88963-dd68-4be2-9a2d-b5843e6247bd",
         "isClosed": "false",
         "isTest": "false",
+        "isRecall”: "false",
         "requestId": "3334",
         "actingUserId": "6136f053-0cfc-49a4-80d2-e20383c27215",
         "id": "E3DB373BA8A52341AFCA01860B4FC9B6",


### PR DESCRIPTION
Given that the new isRecall fact field is available within the Request events, When accessing the Request events specification, Then the isRecall field should be defined.