### PR TITLE
Update apidoc.markdown

### DIFF
--- a/src/api-reference/authentication/apidoc.markdown
+++ b/src/api-reference/authentication/apidoc.markdown
@@ -196,8 +196,8 @@ When refreshing a token or when calling any other APIs, the token's geolocation 
 
 **Note:** Client-side calls should use the www- variant of the base URI.
 
-For example:
-When obtaining a token, if the response was the below:
+#### Example
+Consider an example where your application obtains a token and receives the response below:
 
 ```http
 HTTP/1.1 200 OK
@@ -219,7 +219,7 @@ Connection: Close
 }
 ```
 
-When then calling the receipts API to post a receipt, your request should be made to https://us.api.concursolutions.com (if server side) or https://www-us.api.concursolutions.com (for clients).
+When your application calls another API, such as the receipts API to post a receipt, the request should be made using the base URI specified in the geolocation value of the response.  In the example above, that request would be made to https://us.api.concursolutions.com (if server side) or https://www-us.api.concursolutions.com (for clients).  The geolocation value can be any of the supported base URIs.  The application should store the specific geolocation it receives, and use it as the base URI for future API calls when using that token.
 
 
 ## ID Token <a name="id_token"></a>


### PR DESCRIPTION
Clarify that this section is only an example, and applications should use the base URI they receive, not always send to the US DC.

