### PR TITLE
Update v4.user-provisioning.md

### DIFF
--- a/src/api-reference/user-provisioning/v4.user-provisioning.md
+++ b/src/api-reference/user-provisioning/v4.user-provisioning.md
@@ -41,7 +41,7 @@ Name|Description|Endpoint
 `identity.user.coresensitive.read`|Read core sensitive data.|GET
 `identity.user.enterprise.read`|Read user enterprise data.|GET
 `travel.user.general.read`|Read general Travel data: Manager, Travel Name, RuleClass, Groups, OrgUnit, Travel Custom Fields|GET
-`travel.user.private.read`|Read private Travel data. XML Sync ID, CRSName/GDS Sync ID, Travel Name Remark, Gender|GET
+`travel.user.private.read`|Read private Travel data: CRSName/GDS Sync ID, Travel Name Remark, Gender|GET
 `spend.user.general.writeonly`|Change spend user information.|POST, PUT, PATCH
 `spend.user.general.read`|View spend user information.|GET
 
@@ -1218,7 +1218,6 @@ Content-Type: application/json
             "id": 560485
         },
         "travelCrsName": null,
-        "xmlProfileSyncId": "",
         "gender": "Female",
         "travelNameRemark": "",
         "orgUnit": null,


### PR DESCRIPTION
Removed references to XML Profile Sync ID. We are killing off the XML Profile Sync on March 31 so no reason to support a legacy field in a brand new API. It's still available in TP2.0 API for TMCs who need it.

