### PR TITLE
EKPZH-799: update customer docs for v2 and v3 report APIs

### DIFF
--- a/src/api-reference/expense/expense-report/expense-report-get.markdown
+++ b/src/api-reference/expense/expense-report/expense-report-get.markdown
@@ -8,7 +8,7 @@ layout: reference
 {% include deprecation-alert.html %}
 
 **NOTE:** Find the newer version 3.0 [here.](/api-reference/expense/expense-report/v3.reports.html#retrieve-a-report-by-id-)  
----
+
 
 Retrieves the full set of information for the report. Includes the Report Header, Entry, Attendee, Itemization and Allocation details.  
 

--- a/src/api-reference/expense/expense-report/expense-report-get.markdown
+++ b/src/api-reference/expense/expense-report/expense-report-get.markdown
@@ -5,6 +5,11 @@ layout: reference
 
 # Get Report Details
 
+{% include deprecation-alert.html %}
+
+**NOTE:** Find the newer version 3.0 [here.](/api-reference/expense/expense-report/v3.reports.html#retrieve-a-report-by-id-)  
+---
+
 Retrieves the full set of information for the report. Includes the Report Header, Entry, Attendee, Itemization and Allocation details.  
 
 Some elements will appear only if the OAuth consumer has the Web Services Admin role. These include: The **ReportKey** element, the employee's credit card information, and the employee's bank account information, VAT information, Journal entries. Connectors that utilize this information go through a review process with SAP Concur that includes verification of secure data handling.

--- a/src/api-reference/expense/expense-report/v3.reports.markdown
+++ b/src/api-reference/expense/expense-report/v3.reports.markdown
@@ -14,7 +14,7 @@ redirect_from:
 * [Expense Report Header 1.1](/api-reference/expense/expense-report/v1dot1.reports.html)
 
 ## Retrieve reports owned by the user based on search criteria <a name="get"></a>
-
+>**Note**: This endpoint does not return Central Reconciliation reports.
 ```
 GET  /api/v3.0/expense/reports
 ```


### PR DESCRIPTION
-Adding deprecation message to expense-report-get
-Noting that the v3 get report by search criteria endpoint does not return Central Reconciliation reports