### PR TITLE
EMP-953 Update Spend v4 documentation with restrictions and char length

### DIFF
--- a/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
+++ b/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
@@ -16,15 +16,15 @@ The Spend User Extension provides the basic properties of a Spend Identity.
 |`reimbursementCurrency`|`string`|-|**Required** Valid three digit or letter currency code in the list of system reimbursement currencies. Length: 3 characters|
 |`reimbursementType`|`string`|-|The reimbursement type for the user. Supported values: `ACCOUNTS_PAYABLE`, `ADP_PAYROLL`, `CONCUR_PAY`, `OTHER`. <br>Not a Required field type, but if used, please notes [`ADP Extension`](#adp-extension-schema) if the `ADP_PAYROLL` reimbursement method type is specified in this field.|
 |`ledgerCode`|`string`|-|Ledger code to associate with the user. Maximum Length: 20 characters|
-|`country`|`string`|-|**Required** Valid ISO 3166 country code. Maximum Length: 3 characters|
-|`budgetCountryCode`|`string`|-|Valid ISO 3166 country code for Budget. Maximum Length: 3 characters|
-|`stateProvince`|`string`|-|Valid ISO sub country code. Example: `WA`. Maximum Length: 6 characters|
+|`country`|`string`|-|**Required** Valid ISO 3166 country code. Maximum Length: 2 characters|
+|`budgetCountryCode`|`string`|-|Valid ISO 3166 country code for Budget. Maximum Length: 2 characters|
+|`stateProvince`|`string`|-|Valid ISO sub country code. Example: `WA`. Maximum Length: 5 characters|
 |`locale`|`string`|-|**Required** Valid locale from the list of configured locales as defined in [RFC5646]. Example: `en-US`. Maximum length: 5 characters|
 |`cashAdvanceAccountCode`|`string`|-|Valid cash advance account code. Maximum Length: 20 characters|
 |`testEmployee`|`boolean`|`true`/`false`|A Boolean value indicating whether the user is a test user. Can't be modified after the user is created. Can only be set at creation.|
 |`nonEmployee`|`boolean`|`true`/`false`|A Boolean value indicating whether the user is a non-employee.|
-|`biManager`|[`UserReference`](#user-reference-schema)|-|The employee ID of the Reporting Manager. Must be existing employee ID or in current import. No circular reporting among users, field is nulled if logic in error. Maximum Length: 48 characters|
-|`customData`|[`CustomData`](#custom-data-schema)|-|The Custom Data associated with this user. Maximum length: 48 characters|
+|`biManager`|[`UserReference`](#user-reference-schema)|-|The employee ID of the Reporting Manager. Must be existing employee ID or in current import. No circular reporting among users, field is nulled if logic in error.|
+|`customData`|[`CustomData`](#custom-data-schema)|-|The Custom Data associated with this user.|
 
 ### <a name="custom-data-schema"></a>Custom Data
 
@@ -34,8 +34,8 @@ Custom Data is the object used as the value of `customData` in the Spend User Ex
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-|`id`|`string`|-|`custom1` - `custom22`, `orgUnit1` - `orgUnit6`. Maximum length: 8 characters|
-|`value`|`string`|-|Value of the custom field. For list = List Item Code.|
+|`id`|`string`|-|`custom1` - `custom22`, `orgUnit1` - `orgUnit6`.|
+|`value`|`string`|-|Value of the custom field. For list = List Item Code. Maximum length: 8 characters|
 
 ## <a name="adp-extension-schema"></a>ADP Extension
 
@@ -118,8 +118,8 @@ Temporary delegate is the object that defines the temporary start date and end d
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-|`temporaryDelegationFromDate`|`string`|YYYYMMDD|Start date for delegate's temporary approval permission. Maximum Length: 8 characters|
-|`temporaryDelegationToDate`|`string`|YYYYMMDD|End date for delegate's temporary approval permission. Maximum Length: 8 characters|
+|`temporaryDelegationFromDate`|`string`|-|Start date for delegate's temporary approval permission.|
+|`temporaryDelegationToDate`|`string`|-|End date for delegate's temporary approval permission.|
 
 ## <a name="spend-role-extension-schema"></a>Spend Role Extension
 

--- a/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
+++ b/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
@@ -16,10 +16,10 @@ The Spend User Extension provides the basic properties of a Spend Identity.
 |`reimbursementCurrency`|`string`|-|**Required** Valid three digit or letter currency code in the list of system reimbursement currencies. Length: 3 characters|
 |`reimbursementType`|`string`|-|The reimbursement type for the user. Supported values: `ACCOUNTS_PAYABLE`, `ADP_PAYROLL`, `CONCUR_PAY`, `OTHER`. <br>Not a Required field type, but if used, please notes [`ADP Extension`](#adp-extension-schema) if the `ADP_PAYROLL` reimbursement method type is specified in this field.|
 |`ledgerCode`|`string`|-|Ledger code to associate with the user. Maximum Length: 20 characters|
-|`country`|`string`|-|**Required** Valid ISO 3166 country code. Maximum Length: 2 characters|
-|`budgetCountryCode`|`string`|-|Valid ISO 3166 country code for Budget. Maximum Length: 2 characters|
-|`stateProvince`|`string`|-|Valid ISO sub country code. Example: `WA`. Maximum Length: 5 characters|
-|`locale`|`string`|-|**Required** Valid locale from the list of configured locales as defined in [RFC5646]. Example: `en-US`. Maximum length: 5 characters|
+|`country`|`string`|-|**Required** Valid ISO 3166 country code. Length: 2 characters|
+|`budgetCountryCode`|`string`|-|Valid ISO 3166 country code for Budget. Length: 2 characters|
+|`stateProvince`|`string`|-|Valid ISO sub country code. Example: `WA`. Length: 2 characters|
+|`locale`|`string`|-|**Required** Valid locale from the list of configured locales as defined in [RFC5646]. Example: `en-US`. Length: 5 characters|
 |`cashAdvanceAccountCode`|`string`|-|Valid cash advance account code. Maximum Length: 20 characters|
 |`testEmployee`|`boolean`|`true`/`false`|A Boolean value indicating whether the user is a test user. Can't be modified after the user is created. Can only be set at creation.|
 |`nonEmployee`|`boolean`|`true`/`false`|A Boolean value indicating whether the user is a non-employee.|

--- a/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
+++ b/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
@@ -13,18 +13,18 @@ The Spend User Extension provides the basic properties of a Spend Identity.
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-|`reimbursementCurrency`|`string`|-|**Required** Valid three digit currency code in the list of system reimbursement currencies.|
+|`reimbursementCurrency`|`string`|3 characters only|**Required** Valid three digit or letter currency code in the list of system reimbursement currencies.|
 |`reimbursementType`|`string`|-|The reimbursement type for the user. Supported values: `ACCOUNTS_PAYABLE`, `ADP_PAYROLL`, `CONCUR_PAY`, `OTHER`. <br>Not a Required field type, but if used, please notes [`ADP Extension`](#adp-extension-schema) if the `ADP_PAYROLL` reimbursement method type is specified in this field.|
-|`ledgerCode`|`string`|-|Ledger code to associate with the user.|
-|`country`|`string`|-|**Required** Valid ISO 3166 country code.|
-|`budgetCountryCode`|`string`|-|Valid ISO 3166 country code for Budget.|
-|`stateProvince`|`string`|-|Valid ISO sub country code. Example: `WA`|
-|`locale`|`string`|-|**Required** Valid locale from the list of configured locales as defined in [RFC5646]. Example: `en-US`|
-|`cashAdvanceAccountCode`|`string`|-|Valid cash advance account code.|
+|`ledgerCode`|`string`|20 characters maximum|Ledger code to associate with the user.|
+|`country`|`string`|3 characters maximum|**Required** Valid ISO 3166 country code.|
+|`budgetCountryCode`|`string`|3 characters maximum|Valid ISO 3166 country code for Budget.|
+|`stateProvince`|`string`|6 characters maximum|Valid ISO sub country code. Example: `WA`|
+|`locale`|`string`|5 characters maximum|**Required** Valid locale from the list of configured locales as defined in [RFC5646]. Example: `en-US`|
+|`cashAdvanceAccountCode`|`string`|20 characters maximum|Valid cash advance account code.|
 |`testEmployee`|`boolean`|`true`/`false`|A Boolean value indicating whether the user is a test user. Can't be modified after the user is created. Can only be set at creation.|
 |`nonEmployee`|`boolean`|`true`/`false`|A Boolean value indicating whether the user is a non-employee.|
-|`biManager`|[`UserReference`](#user-reference-schema)|-|The identity of the Reporting Manager.|
-|`customData`|[`CustomData`](#custom-data-schema)|-|The Custom Data associated with this user.|
+|`biManager`|[`UserReference`](#user-reference-schema)|48 characters maximum|The employee ID of the Reporting Manager. Must be existing employee ID or in current import. No circular reporting among users, field is nulled if logic in error.|
+|`customData`|[`CustomData`](#custom-data-schema)|48 characters maximum|The Custom Data associated with this user.|
 
 ### <a name="custom-data-schema"></a>Custom Data
 
@@ -34,7 +34,7 @@ Custom Data is the object used as the value of `customData` in the Spend User Ex
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-|`id`|`string`|-|`custom1` - `custom22`, `orgUnit1` - `orgUnit6`|
+|`id`|`string`|8 characters maximum|`custom1` - `custom22`, `orgUnit1` - `orgUnit6`|
 |`value`|`string`|-|Value of the custom field. For list = List Item Code.|
 
 ## <a name="adp-extension-schema"></a>ADP Extension
@@ -118,8 +118,8 @@ Temporary delegate is the object that defines the temporary start date and end d
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-|`temporaryDelegationFromDate`|`string`|-|Start date for delegate's temporary approval permission.|
-|`temporaryDelegationToDate`|`string`|-|End date for delegate's temporary approval permission.|
+|`temporaryDelegationFromDate`|`string`|8 characters maximum; must be in following format: YYYYMMDD|Start date for delegate's temporary approval permission.|
+|`temporaryDelegationToDate`|`string`|8 characters maximum; must be in following format: YYYYMMDD|End date for delegate's temporary approval permission.|
 
 ## <a name="spend-role-extension-schema"></a>Spend Role Extension
 
@@ -192,4 +192,4 @@ User Reference is the object that defines the identifier fields of a User.
 |Name|Type|Format|Description|
 |---|---|---|---|
 |`value`|`string`|`uuid`|The unique universal identifier of the Spend User. |
-|`employeeNumber`|`string`|-|The employee number of the Spend user. |
+|`employeeNumber`|`string`|48 characters maximum|The employee number of the Spend user. |

--- a/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
+++ b/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
@@ -34,8 +34,8 @@ Custom Data is the object used as the value of `customData` in the Spend User Ex
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-|`id`|`string`|-|`custom1` - `custom22`, `orgUnit1` - `orgUnit6`.|
-|`value`|`string`|-|Value of the custom field. For list = List Item Code. Maximum length: 8 characters|
+|`id`|`string`|-|`custom1` - `custom22`, `orgUnit1` - `orgUnit6`|
+|`value`|`string`|-|Value of the custom field. For list = List Item Code.|
 
 ## <a name="adp-extension-schema"></a>ADP Extension
 

--- a/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
+++ b/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
@@ -146,7 +146,7 @@ By default, the hierarchy structure is navigable via a tree control, and each no
 |`roleName`|`string`|-|**Required** Spend role for a Spend User.|
 |`roleGroups`|`string array`|-|**Required** Group(s) to be associated with the Spend role.|
 
-**NOTE:** Please refer to the [Spend Role Codes](./v4.spend-role-code-definition.html) page for the available value of `roleName`.
+**NOTE:** Please refer to the [Spend Role Codes](./v4.spend-role-code-definition.md) page for the available value of `roleName`.
 
 ## <a name="user-preference-extension-schema"></a>User Preference Extension
 

--- a/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
+++ b/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
@@ -146,7 +146,7 @@ By default, the hierarchy structure is navigable via a tree control, and each no
 |`roleName`|`string`|-|**Required** Spend role for a Spend User.|
 |`roleGroups`|`string array`|-|**Required** Group(s) to be associated with the Spend role.|
 
-**NOTE:** Please refer to the [Spend Role Codes](./v4.spend-role-code-definition.md) page for the available value of `roleName`.
+**NOTE:** Please refer to the [Spend Role Codes](./v4.spend-role-code-definition.html) page for the available value of `roleName`.
 
 ## <a name="user-preference-extension-schema"></a>User Preference Extension
 

--- a/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
+++ b/src/api-reference/user-provisioning/spend/v4.spend-user-extension-schema.md
@@ -13,18 +13,18 @@ The Spend User Extension provides the basic properties of a Spend Identity.
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-|`reimbursementCurrency`|`string`|3 characters only|**Required** Valid three digit or letter currency code in the list of system reimbursement currencies.|
+|`reimbursementCurrency`|`string`|-|**Required** Valid three digit or letter currency code in the list of system reimbursement currencies. Length: 3 characters|
 |`reimbursementType`|`string`|-|The reimbursement type for the user. Supported values: `ACCOUNTS_PAYABLE`, `ADP_PAYROLL`, `CONCUR_PAY`, `OTHER`. <br>Not a Required field type, but if used, please notes [`ADP Extension`](#adp-extension-schema) if the `ADP_PAYROLL` reimbursement method type is specified in this field.|
-|`ledgerCode`|`string`|20 characters maximum|Ledger code to associate with the user.|
-|`country`|`string`|3 characters maximum|**Required** Valid ISO 3166 country code.|
-|`budgetCountryCode`|`string`|3 characters maximum|Valid ISO 3166 country code for Budget.|
-|`stateProvince`|`string`|6 characters maximum|Valid ISO sub country code. Example: `WA`|
-|`locale`|`string`|5 characters maximum|**Required** Valid locale from the list of configured locales as defined in [RFC5646]. Example: `en-US`|
-|`cashAdvanceAccountCode`|`string`|20 characters maximum|Valid cash advance account code.|
+|`ledgerCode`|`string`|-|Ledger code to associate with the user. Maximum Length: 20 characters|
+|`country`|`string`|-|**Required** Valid ISO 3166 country code. Maximum Length: 3 characters|
+|`budgetCountryCode`|`string`|-|Valid ISO 3166 country code for Budget. Maximum Length: 3 characters|
+|`stateProvince`|`string`|-|Valid ISO sub country code. Example: `WA`. Maximum Length: 6 characters|
+|`locale`|`string`|-|**Required** Valid locale from the list of configured locales as defined in [RFC5646]. Example: `en-US`. Maximum length: 5 characters|
+|`cashAdvanceAccountCode`|`string`|-|Valid cash advance account code. Maximum Length: 20 characters|
 |`testEmployee`|`boolean`|`true`/`false`|A Boolean value indicating whether the user is a test user. Can't be modified after the user is created. Can only be set at creation.|
 |`nonEmployee`|`boolean`|`true`/`false`|A Boolean value indicating whether the user is a non-employee.|
-|`biManager`|[`UserReference`](#user-reference-schema)|48 characters maximum|The employee ID of the Reporting Manager. Must be existing employee ID or in current import. No circular reporting among users, field is nulled if logic in error.|
-|`customData`|[`CustomData`](#custom-data-schema)|48 characters maximum|The Custom Data associated with this user.|
+|`biManager`|[`UserReference`](#user-reference-schema)|-|The employee ID of the Reporting Manager. Must be existing employee ID or in current import. No circular reporting among users, field is nulled if logic in error. Maximum Length: 48 characters|
+|`customData`|[`CustomData`](#custom-data-schema)|-|The Custom Data associated with this user. Maximum length: 48 characters|
 
 ### <a name="custom-data-schema"></a>Custom Data
 
@@ -34,7 +34,7 @@ Custom Data is the object used as the value of `customData` in the Spend User Ex
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-|`id`|`string`|8 characters maximum|`custom1` - `custom22`, `orgUnit1` - `orgUnit6`|
+|`id`|`string`|-|`custom1` - `custom22`, `orgUnit1` - `orgUnit6`. Maximum length: 8 characters|
 |`value`|`string`|-|Value of the custom field. For list = List Item Code.|
 
 ## <a name="adp-extension-schema"></a>ADP Extension
@@ -118,8 +118,8 @@ Temporary delegate is the object that defines the temporary start date and end d
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-|`temporaryDelegationFromDate`|`string`|8 characters maximum; must be in following format: YYYYMMDD|Start date for delegate's temporary approval permission.|
-|`temporaryDelegationToDate`|`string`|8 characters maximum; must be in following format: YYYYMMDD|End date for delegate's temporary approval permission.|
+|`temporaryDelegationFromDate`|`string`|YYYYMMDD|Start date for delegate's temporary approval permission. Maximum Length: 8 characters|
+|`temporaryDelegationToDate`|`string`|YYYYMMDD|End date for delegate's temporary approval permission. Maximum Length: 8 characters|
 
 ## <a name="spend-role-extension-schema"></a>Spend Role Extension
 
@@ -192,4 +192,4 @@ User Reference is the object that defines the identifier fields of a User.
 |Name|Type|Format|Description|
 |---|---|---|---|
 |`value`|`string`|`uuid`|The unique universal identifier of the Spend User. |
-|`employeeNumber`|`string`|48 characters maximum|The employee number of the Spend user. |
+|`employeeNumber`|`string`|-|The employee number of the Spend user. Maximum Length: 48 characters|


### PR DESCRIPTION
### What does this PR do?
Update Spend v4 documentation with restrictions and char length

### Motivation and Context:
Users need to know character lengths for fields and chart restrictions. 