### PR TITLE
 Update documentation for Registration, Mappings and Vendors APIs

### DIFF
--- a/src/api-reference/accounting-integration/v4.accountingintegration-account.markdown
+++ b/src/api-reference/accounting-integration/v4.accountingintegration-account.markdown
@@ -155,7 +155,7 @@ Name|Type|Format|Description
 ### Payloads
 
 * Request: None
-* Response: [List of Account](./v4.accountingintegration-schema.html#list-of-account), [Error](./v4.accountingintegration-schema.html#schema-error)
+* Response: [List of Account](./v4.accountingintegration-schema.html#list-of-account), [ErrorMessage](./v4.accountingintegration-schema.html#errorMessage)
 
 ### Examples
 

--- a/src/api-reference/accounting-integration/v4.accountingintegration-list.markdown
+++ b/src/api-reference/accounting-integration/v4.accountingintegration-list.markdown
@@ -43,7 +43,7 @@ Name|Type|Format|Description
 ### Payloads
 
 * Request: [List of ERP List](./v4.accountingintegration-schema.html#list-of-list)
-* Response: [RequestStatus](./v4.accountingintegration-schema.html#request-status), [Error](./v4.accountingintegration-schema.html#schema-error)
+* Response: [RequestStatus](./v4.accountingintegration-schema.html#request-status), [ErrorMessage](./v4.accountingintegration-schema.html#errorMessage)
 
 ### Examples
 

--- a/src/api-reference/accounting-integration/v4.accountingintegration-mappings.markdown
+++ b/src/api-reference/accounting-integration/v4.accountingintegration-mappings.markdown
@@ -35,7 +35,7 @@ GET /accountingintegration/v4/companies/{companyId}/erps/{erpId}/mappings
 ### Payloads
 
 * Request: None
-* Response: [MappingsResponse](./v4.accountingintegration-schema.html#mappings-response), [Error](./v4.accountingintegration-schema.html#schema-error)
+* Response: [MappingsResponse](./v4.accountingintegration-schema.html#mappings-response), [ErrorMessage](./v4.accountingintegration-schema.html#errorMessage)
 
 ### Examples
 
@@ -55,6 +55,8 @@ GET /accountingintegration/v4/companies/09ac834c-46d6-49ff-9653-551d69072d56/erp
 {
   "erpId": "string",
   "ledger": {
+    "name": "string",
+    "code": "string",
     "expenseHierarchy": [
       {
         "formTypeCode": "string",
@@ -68,9 +70,7 @@ GET /accountingintegration/v4/companies/09ac834c-46d6-49ff-9653-551d69072d56/erp
         "alternateFieldId": "string",
         "level": 0
       }
-    ],
-    "code": "string",
-    "name": "string"
+    ]
   },
   "features": [
     {
@@ -127,6 +127,10 @@ GET /accountingintegration/v4/companies/09ac834c-46d6-49ff-9653-551d69072d56/erp
         "number": "string",
         "name": "string",
         "type": "ACCOUNTS_PAYABLE"
+      },
+      "billableField": {
+        "formTypeCode": "allocation",
+        "alternateFieldId": "string"
       }
     }
   ]

--- a/src/api-reference/accounting-integration/v4.accountingintegration-registration.markdown
+++ b/src/api-reference/accounting-integration/v4.accountingintegration-registration.markdown
@@ -13,7 +13,6 @@ This endpoint is to register a given ERP integration.
 
 ### Limitations
 
-* Access to this documentation does not provide access to the API. 
 * This endpoint can be called once every minute.
 
 ### Scopes
@@ -37,7 +36,7 @@ Name|Type|Format|Description
 ### Payloads
 
 * Request: [ErpPackage](./v4.accountingintegration-schema.html#erp-package)
-* Response: [ErpPackage](./v4.accountingintegration-schema.html#erp-package), [Error](./v4.accountingintegration-schema.html#schema-error)
+* Response: [ErpPackage](./v4.accountingintegration-schema.html#erp-package), [ErrorMessage](./v4.accountingintegration-schema.html#errorMessage)
 
 ### Examples
 
@@ -115,10 +114,12 @@ PATCH /accountingintegration/v4/companies/09ac834c-46d6-49ff-9653-551d69072d56/e
 ```json
 {
   "features": [
-    "SUPPORTS_RECEIPT_POSTING"
+    "SUPPORTS_RECEIPT_POSTING",
+    "SUPPORTS_LIABILITY_ACCOUNT"
   ]
 }
 ```
+Make sure to pass ALL the active flags in the PATCH request
 
 #### Response
 
@@ -130,7 +131,8 @@ PATCH /accountingintegration/v4/companies/09ac834c-46d6-49ff-9653-551d69072d56/e
 {
   "partnerAppName": "SomePartnerName",
   "features": [
-    "SUPPORTS_RECEIPT_POSTING"
+    "SUPPORTS_RECEIPT_POSTING",
+    "SUPPORTS_LIABILITY_ACCOUNT"
   ],
   "erpName": "SomeErpName",
   "externalErpId": "SomeErpId",

--- a/src/api-reference/accounting-integration/v4.accountingintegration-request.markdown
+++ b/src/api-reference/accounting-integration/v4.accountingintegration-request.markdown
@@ -38,7 +38,7 @@ Name|Type|Format|Description
 ### Payloads
 
 * Request: None
-* Request: [RequestStatus](./v4.accountingintegration-schema.html#request-status), [Error](./v4.accountingintegration-schema.html#schema-error)
+* Request: [RequestStatus](./v4.accountingintegration-schema.html#request-status), [ErrorMessage](./v4.accountingintegration-schema.html#errorMessage)
 
 ### Example
 

--- a/src/api-reference/accounting-integration/v4.accountingintegration-schema.markdown
+++ b/src/api-reference/accounting-integration/v4.accountingintegration-schema.markdown
@@ -39,14 +39,23 @@ Name|Type
 `OTHER_EXPENSE`|`string`
 `OTHER_INCOME`|`string`
 
-### <a name="schema-error"></a>Error
+### <a name="billableField"></a>BillableField
 
 Name|Type|Format|Description
 ---|---|---|---
+`formTypeCode`|`string`|[`FormTypeCode`](#form-type-code)|Form type code to match with the Financial Information document.
+`alternateFieldId`|`string`|-|Field ID to match with the Financial Information document.
+
+### <a name="errorMessage"></a>ErrorMessage
+
+Name|Type|Format|Description
+---|---|---|---
+`timestamp`|`string`|-|The time when the error was captured.
+`httpStatus`|`string`|-|The http response code and phrase for the response.
 `errorCode`|`string`|-|Machine readable code associated with the error which is static and never localized.
 `errorMessage`|`string`|-|Message associated with the error.
 `path`|`string`|-|Relative data path.
-`validationErrors`|`array`|[`error`](#schema-error)|A list of validation error messages if applicable.
+`validationErrors`|`array`|[`ValidationError`](#validation-error)|A list of validation error messages if applicable.
 
 ### <a name="erp-package"></a>ErpPackage
 
@@ -63,6 +72,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `SUPPORTS_RECEIPT_POSTING`|`string`|-|Pass this flag if ERP supports Expense receipts and Invoice images.
+`SUPPORTS_LIABILITY_ACCOUNT`|`string`|-|Pass this flag if ERP supports Liabliltiy account.
 
 ### <a name="feature"></a>Feature
 
@@ -94,6 +104,8 @@ Name|Type|Format|Description
 `paymentTypes`|`array`|[`PaymentType`](#payment-type)|List of payment type configurations.
 `listMappings`|`array`|[`ListMapping`](#list-mapping)|List of ERP list to SAP Concur platform list mappings.
 `invoiceLiabilityAccount`|-|[`Account`](#erp-account)|Invoice liability account code and name.
+`billableField`|-|[`BillableField`](#billableField)|Field that shows if the expense entry is Billable or not.
+
 
 ### <a name="form-type-code"></a>FormTypeCode
 
@@ -180,8 +192,9 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `erpId`|`string`|`UUID`|Universally unique identifier of the ERP.
+`ledger`|-|`Ledger`| (**Currently not supported, future enhancement**)Concur Ledger Information.
 `features`|`array`|[`Feature`](#feature)|List of features that the company will use.
-`files`|`array`|[`FileMapping`](#file-mapping)|List of the settings and mappings for each ERP file that the company uses. Could be a single entry if files are not used in the ERP.
+`files`|`array`|[`FileMapping`](#file-mapping)|(**Currently not supported, future enhancement**)List of the settings and mappings for each ERP file that the company uses. Could be a single entry if files are not used in the ERP.
 
 ### <a name="object-type"></a>ObjectType
 
@@ -241,8 +254,8 @@ Name|Type|Format|Description
 `type`|`string`|[`VendorType`](#vendor-type)|**Required** The type of the vendor.
 `currencyCode`|`string`|`ISO 4217`|**Required for accounting type vendor** 3-letter currency code.
 `name`|`string`|-|**Required for accounting type vendor** The name of the vendor.
-`lastName`|`string`|-|**Required for employee type vendor**
-`firstName`|`string`|-|**Required for employee type vendor**
+`lastName`|`string`|-|**Required for employee type vendor** will display in User Administration UI
+`firstName`|`string`|-|**Required for employee type vendor** will display in User Administration UI
 `email`|`string`|-|**Required for employee type vendor**
 `employeeId`|`string`|-|**Required for employee type vendor** Unique identifier of the employee vendor.
 `companyName`|`string`|-|**Required for accounting type vendor** Company name.

--- a/src/api-reference/accounting-integration/v4.accountingintegration-vendor.markdown
+++ b/src/api-reference/accounting-integration/v4.accountingintegration-vendor.markdown
@@ -42,7 +42,7 @@ Name|Type|Format|Description
 ### Payloads
 
 * Request: [List of Vendor](./v4.accountingintegration-schema.html#list-of-vendor)
-* Request: [RequestStatus](./v4.accountingintegration-schema.html#request-status), [Error](./v4.accountingintegration-schema.html#schema-error)
+* Request: [RequestStatus](./v4.accountingintegration-schema.html#request-status), [ErrorMessage](./v4.accountingintegration-schema.html#errorMessage)
 
 ### Examples
 


### PR DESCRIPTION
1. update the ErrorMessage schema to add timestamp and httpstatus
2. update Vendor schema to indicate that only first and last name will show in UI
3. Update the Mappings API documentation to the latest format (match the service Swagger) to include the IsBillable mapping
4. Update Registration API documentation to include the new flag SUPPORTS_LIABILITY_ACCOUNT and what it is used for Also update the flags update documentation to make it clear that they need to send ALL the active flags in the PATCH request, even if some were sent with the POST Registration API.