### PR TITLE
TVR-16354 Next documentation update on Request v4 API

### DIFF
--- a/src/api-reference/request/v4.endpoints.schemas.markdown
+++ b/src/api-reference/request/v4.endpoints.schemas.markdown
@@ -54,7 +54,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `value`|`number`|-|**Required** The amount in the defined currency.
-`currency`|`string`|[ISO 4217:2015]|**Required** The 3-letter ISO 4217 code for the currency in which the amount is expressed.
+`currency`|`string`|[ISO 4217:2015]|**Required** The 3-letter ISO 4217 code for the currency in which the amount is expressed. Max length 3 characters.
 
 ## <a name="schema-approvalstatus"></a>Approval Status
 
@@ -163,7 +163,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `city`|`string`|-|**Required for all city location type (not airport, or rail station - except for STD location type)** The city name of the location. <br>Note: STD location type for rail is considered as a city location type, `city` and `countryCode` fields are required in that case.
-`countryCode`|`string`|[ISO 3166-1]|**Required if `city` or `name` is used** The ISO 3166-1 country code.
+`countryCode`|`string`|[ISO 3166-1]|**Required if `city` or `name` is used** The ISO 3166-1 country code. Max length 2 characters.
 `countrySubDivisionCode`|`string`|[ISO 3166-2]|The ISO 3166-2 country sub code.
 `iataCode`|`string`|-|**Required if `air` is used** The IATA code of an airport location.
 `id`|`string`|-|The id of the location.
@@ -448,7 +448,7 @@ If `proposalSegmentType` is `MISC` then include fields of [`Agency proposal misc
 
 Name|Type|Format|Description
 ---|---|---|---
-`classOfService`|`string`|-|**Required** The class of the air segment (e.g. `Business`).
+`classOfService`|`string`|-|**Required** The class of the air segment (e.g. `Business`). Will be displayed as information within the proposal comparison screen. Max Length: 32 characters.
 `classListItem`|`object`|[`ResourceLink`](#schema-resourcelink)|The unique identifier of the class of service list item for the segment. It will populate the "Class" list field of the air segment form. If the "Class" List field of the air segment form is mandatory, then this field becomes **Request** within the proposal payload.
 `duration`|`integer`|-|**Required** The duration of the booked flight in minutes. Must be greater than 0 (e.g. `120` for a two hours flight).
 `flightNumber`|`string`|-|**Required** The flight number for the booking (e.g. `AF029`)
@@ -463,7 +463,7 @@ Name|Type|Format|Description
 
 Name|Type|Format|Description
 ---|---|---|---
-`classOfService`|`string`|-|**Required** The class of the segment leg (e.g. `Economy`)
+`classOfService`|`string`|-|**Required** The class of the segment leg (e.g. `Economy`). Will be displayed as information within the proposal comparison screen. Max Length: 32 characters.
 `classListItem`|`object`|[`ResourceLink`](#schema-resourcelink)|The unique identifier of the class of service list item for the air segment. It will populate the "Class" list field of the rail segment form. If the "Class" List field of the rail segment form is mandatory, then this field becomes **Request** within the proposal payload.
 `duration`|`integer`|-|**Required** The duration of the booked train in minutes. Must be greater than 0. Must be greater than 0 (e.g. `120` for a two hours ride).
 `trainNumber`|`string`|-|**Required** The train number for the booking (e.g. `1578`)
@@ -482,7 +482,7 @@ Name|Type|Format|Description
 ---|---|---|---
 `airConditioning`|`boolean`|-|Indicates if car has an air conditioner.
 `carEquipment`|`string`|-|Any special equipment required by the renter (e.g. `GPS`).
-`classOfService`|`string`|-|The class of the segment leg (e.g. `Eco/Compact`).
+`classOfService`|`string`|-|The class of the segment leg (e.g. `Eco/Compact`). Will be displayed as information within the proposal comparison screen. Max Length: 32 characters.
 `classListItem`|`object`|[`ResourceLink`](#schema-resourcelink)|The unique identifier of the class of service of the car segment. It will populate the "Class" list field of the car segment form. If the "Class" List field of the car segment form is mandatory, then this field becomes **Request** within the proposal payload.
 `transmissionPreference`|`string`|-|The character code that indicates if the car has auto-transmission. Supported values `A` for Auto or `M` for Manual.
 `dropOffCollectionPhoneNumber`|`string`|-|The phone number for the drop-off address when the rental service offers drop-off.
@@ -497,7 +497,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `name`|`string`|-|**Required** The hotel name for the booking.
-`roomDescription`|`string`|-|The room description for the booking. Max Length: 2000.
+`roomDescription`|`string`|-|The room description for the booking. Max Length: 2000 characters.
 `providerPhone`|`string`|-|The phone number for the booking.
 `location`|`object`|[`Location`](#schema-location)|**Required** The location of the hotel segment leg (city location schema).
 `locationDetail`|`string`|-|Additional details about the location.


### PR DESCRIPTION
limitation on field size is not well documented
Examples :
classOfService is limited to 32 characters
countryCode is limited to 2 characters
currencyCode is limited to 3 characters

