### PR TITLE
Adding `OTHER` as sustainability label provider 

### DIFF
--- a/src/api-explorer/v4-0/HotelService.swagger2.json
+++ b/src/api-explorer/v4-0/HotelService.swagger2.json
@@ -662,7 +662,8 @@
         "GREEN_LEAF",
         "LEED",
         "GREEN_GROWTH_2050",
-        "GREEN_SEAL"
+        "GREEN_SEAL",
+        "OTHER"
       ],
       "example": "EARTH_CHECK",
       "type": "string"
@@ -2350,6 +2351,11 @@
         "level": {
           "description": "Optional level of certification",
           "example": "Gold",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of certification in case when not possible to map to currently supported labels",
+          "example": "Custom",
           "type": "string"
         }
       },

--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
@@ -1963,12 +1963,13 @@ Representation of nightly fees associated with a rate for given dates along with
 
 ### <a id="schemasustainabilityaward"></a> SustainabilityAward
 
-Award or certification related to sustainability awarded to the hotel.
+Award or certification related to sustainability awarded to the hotel. If certification name is not known, it is possible to use `OTHER` as `label` and provide additional `name` attribute. 
 
 |Name|Type|Format|Description|
 |---|---|---|---|
-`label`|[`SustainabilityProvider`](#schemasustainabilityprovider)|-|**Required** Name or label of the award/certification. Supported values: `GSTC`,`EARTH_CHECK`,`GREEN_GLOBE`,`GREEN_KEY`,`TRAVELIFE`,`GREEN_LEAF`,`LEED`,`GREEN_GROWTH_2050`,`GREEN_SEAL`|
+`label`|[`SustainabilityProvider`](#schemasustainabilityprovider)|-|**Required** Name or label of the award/certification. Supported values: `GSTC`,`EARTH_CHECK`,`GREEN_GLOBE`,`GREEN_KEY`,`TRAVELIFE`,`GREEN_LEAF`,`LEED`,`GREEN_GROWTH_2050`,`GREEN_SEAL`, `OTHER`|
 `level`|`string`|-|Optional level of certification.|
+`name` |`string`|-|Name of certification in case when not possible to map to currently supported labels (`OTHER` is used).|
 
 ### <a id="schemalegalentity"></a> LegalEntity
 


### PR DESCRIPTION
This also allows passing actual name as string with value.

