### PR TITLE
ARCH-1337: Fixing Cost Object Workflow mistakes, adding workflow pages to sidebar

### DIFF
--- a/src/_data/sidebars/api-reference.yml
+++ b/src/_data/sidebars/api-reference.yml
@@ -155,6 +155,10 @@
         url: /api-reference/expense/expense-report/v4.expenses.html
       - title: Reports v4
         url: /api-reference/expense/expense-report/v4.reports.html
+      - title: Workflows v4
+        url: /api-reference/expense/expense-report/v4.workflows.html
+      - title: Cost Objects Workflows v4
+        url: /api-reference/expense/expense-report/v4.cost-objects.html
 - title: Financial Integration Service v4
   url: ''
   children:

--- a/src/api-reference/expense/expense-report/v4.cost-objects.markdown
+++ b/src/api-reference/expense/expense-report/v4.cost-objects.markdown
@@ -1,11 +1,11 @@
 ---
-title: Workflow v4
+title: Cost Object Worflows v4
 layout: reference
 ---
 
-# Workflow v4
+# Cost Object Worflows v4
 
-The Workflow API can be used to view reports and cost objects that are pending approval.
+The Cost Object Workflows API can be used to view a reports cost objects that are pending approval.
 
 ## <a name="limitations"></a>Limitations
 


### PR DESCRIPTION
This PR adds in corrections after viewing the results of the previous PR:
https://github.com/SAP-docs/preview.developer.concur.com/pull/597

Problems solved:

- The cost object page was too similar to the workflow page.
- The workflow and cost object page were not visible/accessible on the sidebar.