### PR TITLE
QES-4439 : QE API POST does not create expense with location unless name is given CRMC-197307

### DIFF
--- a/src/api-reference/expense/quick-expense/v4.quick-expense.md
+++ b/src/api-reference/expense/quick-expense/v4.quick-expense.md
@@ -120,7 +120,7 @@ curl -X POST \
     "countryCode": "US",
     "countrySubDivisionCode": "US-WA",
     "id": "",
-    "name": ""
+    "name": "Bellevue"
   },
   "paymentTypeId": "CASHX",
   "transactionAmount": {


### PR DESCRIPTION
Update documentation to reflect location name in the example.

