### PR TITLE
Added clarification that leadRate can be left out if property is closed out

### DIFF
--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
@@ -1528,7 +1528,7 @@ Hotel property object returned by hotel search
 `contactInfo`|[`ContactInfo`](#schemacontactinfo)|-|**Required** Contact information for property.|
 `position`|[`Geolocation`](#schemageolocation)|-|Geolocation of property.|
 `address`|[`Address`](#schemaaddress)|-|**Required** Address of property.|
-`leadRate`|[`LeadRate`](#schemaleadrate)|-|**Required** The lowest nightly rate averaged over the stay.|
+`leadRate`|[`LeadRate`](#schemaleadrate)|-|**Required** The lowest nightly rate averaged over the stay. Not required if `availabilityStatus` is `CLOSED_OUT`|
 `availabilityStatus`|[`AvailabilityStatus`](#schemaavailabilitystatus)|-|**Required** Supported values: `AVAILABLE_FOR_SALE`, `CLOSED_OUT` |
 `preferenceRank`|[`PreferenceRank`](#schemapreferencerank)|-|Supported values: `PREFERRED`, `MORE_PREFERRED`, `MOST_PREFERRED`. This value will override any preferences set by company admins.|
 `preferenceLevel`|[`preferenceLevel`](#schemapreferencelevel)|-|Supported values: `CHAIN`, `PROPERTY`. Note that value can be set to `CHAIN` for hotels preferred at both chain or superchain level and this is what is displayed to user as UI as `Preferred Chain`.|


### PR DESCRIPTION
Lead rate may not be available if property is not available for sale and hence can be left out.

