### PR TITLE
Create config.yml to ignore default issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+# Enable blank issues and overwrite organization issue templates
+blank_issues_enabled: true


### PR DESCRIPTION
Hi there,

we're working on a central issue template and a central pull request template for all repositories belonging to the open documentation initiative. Once we're ready, these templates will become the default templates for all repositories in the `SAP-docs` org. Since they are specific for the initiative, it doesn't make sense if you use them.

But no worries, we can ignore them for your repository. I saw that you already use your own `PULL_REQUEST_TEMPLATE.md`. To ignore our new issue template, we need to create a folder ISSUE_TEMPLATE with a single `config.yml` file in it. 

I tested this on our local GHES instance.

