### PR TITLE
TVR-20473 Request swagger fix

### DIFF
--- a/src/api-explorer/v4-0/ConcurRequest-ea.swagger2.json
+++ b/src/api-explorer/v4-0/ConcurRequest-ea.swagger2.json
@@ -42,7 +42,7 @@
     }
   ],
   "paths": {
-    "/travelrequest/requests": {
+    "/requests": {
       "get": {
         "tags": [
           "Request Resource"

--- a/src/api-explorer/v4-0/ConcurRequest.swagger2.json
+++ b/src/api-explorer/v4-0/ConcurRequest.swagger2.json
@@ -38,7 +38,7 @@
     }
   ],
   "paths": {
-    "/travelrequest/requests": {
+    "/requests": {
       "get": {
         "tags": [
           "Request Resource"


### PR DESCRIPTION
Request Swagger : removing the travelrequest prefix which is already on the base path.