### PR TITLE
CARDS-8905 Cards v4: Add test user limitation

### DIFF
--- a/src/api-reference/cards/v4.cards-endpoints.account.markdown
+++ b/src/api-reference/cards/v4.cards-endpoints.account.markdown
@@ -37,6 +37,7 @@ Notes:
 * The `externalId` is a unique identifier (token) for a card account as defined by an external system (outside the SAP Concur platform). It must not contain the primary account number (PAN).
 * Accounts with accountType `V` must reference a billingAccount via `externalId` (which has to be of type `M` or `I`). The billingAccount may be part of the same bulk request or sent before.
 * The owner of the account is identified via `cardholder` attributes based on the following order of priority: `userId`, `employeeId`, `email` (first match is considered).
+  * test users are not supported and cannot be assigned to accounts sent via this API
 
 ###  Headers
 


### PR DESCRIPTION
Add limitation about test users.
* test users can never be assigned to productive card accounts (only to test accounts)
* test accounts are currently not supported by the Cards v4 API

Test user feature: https://www.concurtraining.com/customers/tech_pubs/Docs/_Current/SG_Shr/Shr_SG_Test_User.pdf