### PR TITLE
CARDS-9327 Remove PERS as allowed value for cardProductType

### DIFF
--- a/src/api-explorer/v4-0/Cards.oas3.json
+++ b/src/api-explorer/v4-0/Cards.oas3.json
@@ -296,12 +296,11 @@
           },
           "cardProductType": {
             "type": "string",
-            "description": "Card product type<li>CORP - Corporate Card</li><li>BUSN - Business Card</li><li>PERS - Personal Card</li>",
+            "description": "Card product type<li>CORP - Corporate Card</li><li>BUSN - Business Card</li>",
             "example": "CORP",
             "enum": [
               "CORP",
-              "BUSN",
-              "PERS"
+              "BUSN"
             ]
           },
           "cardholder": {

--- a/src/api-reference/cards/v4.cards-endpoints.schemas.markdown
+++ b/src/api-reference/cards/v4.cards-endpoints.schemas.markdown
@@ -22,7 +22,7 @@ Name|Type|Format|Description
 `billingAccount`|`object`|[`Billing Account Reference`](#schema-billingaccountreference)|Reference to the billing account, e.g. in case of virtual card this references the managing/master account.
 `cardBrand`|`enum`|-|Brand of the card. Supported values: `AX - American Express`, `CA - MasterCard`, `CB - Carte Blanche`, `DC - Diners Club`, `DS - Discover`, `EC - EuroCard`, `ER - ENROUTE`, `JC - JCB International`, `OT - Other`, `TP - UATP Card`, `UP - China Union Pay`, `VI - VISA`
 `cardProductDescription`|`string`|-|**Required** Branded name of the credit card; might be used for display purposes.
-`cardProductType`|`enum`|-|**Required** Card product type. Supported values: `CORP - Corporate Card`, `BUSN - Business Card`, `PERS - Personal Card`
+`cardProductType`|`enum`|-|**Required** Card product type. Supported values: `CORP - Corporate Card`, `BUSN - Business Card`
 `cardholder`|`object`|[`Cardholder`](#schema-cardholder)|Cardholder owning this card account.
 `externalId`|`string`|-|**Required** Unique identifier (token) for a card account as defined by an external system (outside SAP Concur). Must not contain primary account number (PAN).
 `lastSegment`|`string`|-|**Required** Last four digits of the credit card number.


### PR DESCRIPTION
It does not make sense that partners can send personal card data via the new Cards v4 API because:
* we do not support it technically
* also from a business perspective, the way how it is designed today (enterprise apps setup by client admin) does not allow to integrate personal cards of individual employees

No release notes required, since we know that this is only used by one pilot partner for now.