### PR TITLE
ERS-9789: Finish isExpenseRejected to patch expense documentation

### DIFF
--- a/src/api-reference/expense/expense-report/v4.expenses.markdown
+++ b/src/api-reference/expense/expense-report/v4.expenses.markdown
@@ -840,7 +840,7 @@ curl --location --request PATCH 'https://us.api.concursolutions.com/expenserepor
 ```
 ## Update a Specific Expense Entry in a Submitted Report <a name="update-expense-entry-in-a-submitted-report"></a>
 
-Updates the specified expense in an unsubmitted or submitted report and is restricted to modify 'Business Purpose' and 'Custom/Org unit' fields only.
+Updates the specified expense in an unsubmitted or submitted report and is restricted to modify 'Business Purpose', 'Custom/Org unit', and 'isExpenseRejected' fields only.
 
 ### Scopes
 

--- a/src/api-reference/expense/expense-report/v4.reports.markdown
+++ b/src/api-reference/expense/expense-report/v4.reports.markdown
@@ -415,7 +415,7 @@ curl --location --request PATCH 'https://us.api.concursolutions.com/expenserepor
 
 The Approve function advances the specified report to the next step if it is in a system step. The Send Back function sends back the specified report to report owner.
 
-Please note that if any expense on a report has been marked with `isExpenseRejected`, a comment is mandatory for an Approve action.
+Please note that if any expense on a report has been marked with `isExpenseRejected`, a comment is mandatory for an Approve action. This comment should explain why the selected expenses are being returned to the user.
 
 ### Scopes
 


### PR DESCRIPTION
Missed a section when previously updating isExpenseRejected documentation (https://github.com/SAP-docs/preview.developer.concur.com/pull/728)