### PR TITLE
[LINK-9528] Removing text "(deprecated in v3.2)" from NextPage

### DIFF
--- a/src/api-reference/common/connection-requests/connection-requests-resource.markdown
+++ b/src/api-reference/common/connection-requests/connection-requests-resource.markdown
@@ -151,7 +151,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `Items`|`array`|[Connection Request](#connection-request)|The result collection.
-`NextPage`|`string`|-|The URI of the next page of results, if any. (deprecated in v3.2)
+`NextPage`|`string`|-|The URI of the next page of results, if any.
 
 ### <a name="connection-request"></a>Connection Request
 


### PR DESCRIPTION
Text forgotten to be removed in Connection Request documentation update.