### PR TITLE
ERS-13943 - GET /reports/{id} - Include MANAGER and PROCESSOR contexts for externalization

### DIFF
--- a/src/api-explorer/v4-0/Reports.swagger.json
+++ b/src/api-explorer/v4-0/Reports.swagger.json
@@ -730,6 +730,8 @@
               "type": "string",
               "enum": [
                 "TRAVELER",
+                "MANAGER",
+                "PROCESSOR",
                 "PROXY"
               ]
             }

--- a/src/api-reference/expense/expense-report/v4.reports.markdown
+++ b/src/api-reference/expense/expense-report/v4.reports.markdown
@@ -65,11 +65,11 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|string|-|**Required** The unique identifier of the report that is being read.|
+|Name|Type|Format| Description                                                                                                                                                                |
+|---|---|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|`userID`|`string`|-| **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`.                        |
+|`contextType`|`string`|-| **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `MANAGER`, `PROCESSOR`, `PROXY` |
+|`reportId`|string|-| **Required** The unique identifier of the report that is being read.                                                                                                       |
 
 #### Headers
 


### PR DESCRIPTION
GET /reports/{id} (Get Report Details) endpoint was externalized back in 2018 (related Jira [ERS-1231](https://jira.concur.com/browse/ERS-1231)).  At the time it was externalized the team decided to only open up the TRAVELER and PROXY contexts.  Now we would like to include MANAGER and PROCESSOR contexts for externalization.  In particular, this is to suit the CO approver portal use case where approvers would like to see details of the CO reports to approve.