### PR TITLE
ATTEND-1253: Remove Auditing-Related Fields from Schema (clean old ref)

### DIFF
--- a/src/api-reference/common/attendees/v4.attendees.markdown
+++ b/src/api-reference/common/attendees/v4.attendees.markdown
@@ -449,7 +449,7 @@ Name|Type|Format|Description
 |---|---|---|---|
 `attendeeTypeCode`|`string` |-| **Required** A code that indicates the type of attendee. Examples: `EMPLOYEE`, `SPOUSE`, `BUSGUEST`. Maximum length: `8 characters`
 `company`|`string` |-| **Required** The name of the attendee's company. Maximum length: `150`
-`currencyCode`|`string` |-| **Required** The 3-letter ISO 4217 currency code for monetary amounts related to an attendee.
+`currencyCode`|`string` |-| **Required** The 3-letter ISO 4217 currency code for monetary amounts related to an attendee. Default Value: `USD`
 `custom1 through custom25`|`object` |[`Custom Field`](#custom-field-schema)|A custom field associated with the attendee. This field may or may not have data, depending on how Expense form fields are configured. If this field is not configured for the attendee type in question, the response excludes this field. For `custom1-20`, maximum length: `100 characters`. For `custom21-25`, maximum length: `48 characters`
 `externalId`|`string` |-| **Required** An identifier for the attendee, usually assigned outside of the SAP Concur systems. Maximum length: `48 characters` **NOTE:** For HCP connectors where information returned to the SAP Concur systems represent one record per attendee+address pair, this value should be a unique identifier for that pair, and the unique identifier for the individual should be placed into a custom field.
 `firstName`|`string` |-| **Required** The attendee's first name. Maximum length: `50 characters`
@@ -474,7 +474,7 @@ Name|Type|Format|Description
 |---|---|---|---|
 `attendeeTypeCode`|`string` |-| **Required** A code that indicates the type of attendee. Examples: `EMPLOYEE`, `SPOUSE`, `BUSGUEST`. Maximum length: `8 characters`
 `company`|`string` |-| The name of the attendee's company. Maximum length: `150`
-`currencyCode`|`string`|-| **Required if `totalAmountYtd` value is populated** The 3-letter ISO 4217 currency code for monetary amounts related to an attendee.
+`currencyCode`|`string`|-| The 3-letter ISO 4217 currency code for monetary amounts related to an attendee.
 `custom1 through custom25`|`string`|-|A custom field associated with the attendee. This field may or may not have data, depending on how Expense is configured. If a specific custom field is not configured for the attendee type in question and the request contains a value, inserts or updates of that value are not honored. For `custom1-20`, maximum length: `100 characters`. For `custom21-25`, maximum length: `48 characters`
 `externalId`|`string` |-| An identifier for the attendee, usually assigned outside of the SAP Concur systems. Maximum length: `48 characters` **NOTE:** For HCP connectors where information returned to the SAP Concur systems represent one record per attendee+address pair, this value should be a unique identifier for that pair, and the unique identifier for the individual should be placed into a custom field.
 `firstName`|`string` |-| The attendee's first name. Maximum length: `50 characters`


### PR DESCRIPTION
Thank you for your reviews @RoAnnC1. Caught this old reference to the field that was removed in https://github.com/SAP-docs/preview.developer.concur.com/commit/8a3be31cd4a75675f024953ad4dab18b7a42829e

Also added default value for further reader / user clarity