### PR TITLE
Merge - Configuring rubygem to be compatible with ruby 2.7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: Installing Ruby dependencies.
           command: |
-                gem update --system 2.7.4
+                gem update --system 3.1.6
                 gem install bundler   
       - run:
           name: Bundle installation.


### PR DESCRIPTION
Configuring rubygem to be compatible with ruby 2.7.4