### PR TITLE
Added DeepLink Travel Page to the ToC and changed Filename and Title

### DIFF
--- a/src/_data/sidebars/api-guides.yml
+++ b/src/_data/sidebars/api-guides.yml
@@ -58,6 +58,8 @@
 - title: Travel
   url: ''
   children:
+      - title: Deeplink URL Integration
+        url: /api-guides/travel/deeplink-integration.html
       - title: Duty of Care
         url: /api-guides/travel/duty-of-care.html
       - title: Itinerary - GET Itinerary & Trip Details

--- a/src/api-guides/travel/deeplink-integration.markdown
+++ b/src/api-guides/travel/deeplink-integration.markdown
@@ -3,7 +3,7 @@ title: Deeplink Integration for Travel
 layout: reference
 ---
 
-# Deeplink Integration for Travel
+# Deeplink URL Integration - Concur Travel
 
  **Important**: This feature is currently in pre-release status and is only available to approved early access participants. It is under development and might change before being generally released. To become an early access participant, contact your SAP Concur Representative.
 


### PR DESCRIPTION
- Added the Deeplink Travel Page to table of contents. 
- Also changed the ending of the filename from ".md" to ".markdown" and the Title of the DeepLink Travel Page for a better consistency with other DeepLink Integration Request page