### PR TITLE
remove only internal available field from travel search event docu

### DIFF
--- a/src/event-topics/travel/v4.travel-search-events.md
+++ b/src/event-topics/travel/v4.travel-search-events.md
@@ -1,5 +1,5 @@
 ---
-title: Concur Travel Search Events
+title: SAP Concur Travel Search Events
 layout: reference
 ---
 
@@ -39,7 +39,6 @@ Name|Type|Format|Description
 `correlationId`|`string`|`GUID`|Uniquely identifies the air search request.
 `eventType`|`string`|-|Identifies the search event type. Supported values: `travelSearchAir`
 `topic`|`string`|-|Topic for subscription. Supported values: `concur.travel.search`
-`subTopic`|`string`|-|Identifies a subtopic. Supported values: `airshop.v1.schedule`, `airshop.v1.price`, `null`
 `timeStamp`|`string`|`YYYY-MM-DDTHH:MM:SS.fZ`|Search event time in UTC.
 `facts`|`object`|[Air Search Facts](#schema-air-search-facts)|Facts for air search.
 
@@ -86,7 +85,6 @@ Name|Type|Format|Description
 `correlationId`|`string`|`GUID`|Uniquely identifies the hotel search request.
 `eventType`|`string`|-|Identifies the search event type. Supported  values: `travelSearchHotel`
 `topic`|`string`|-|Topic for subscription. Supported values: `concur.travel.search`
-`subTopic`|`string`|-|Identifies subtopic. Supported values: `hotelshop.v1.price`, `null`
 `timeStamp`|`string`|`YYYY-MM-DDTHH:MM:SS.fZ`|Search event time in UTC.
 `facts`|`object`|[Hotel Search Facts](#schema-hotel-search-facts)|Facts for hotel search.
 
@@ -118,7 +116,6 @@ Sample roundtrip air search
   "topic": "concur.travel.search",
   "timeStamp": "2018-10-15T14:19:06.395349006Z",
   "data": null,
-  "subtopic": null,
   "facts": {
     "companyId": "0af6e6ec-c0e6-427e-b397-a38d70276fb1",
     "userId": "5040b878-da00-47c7-8676-e0f6c67885b5",
@@ -187,7 +184,6 @@ Sample roundtrip air search
   "eventType": "travelSearchHotel",
   "topic": "concur.travel.search",
   "data": null,
-  "subTopic": null,
   "timeStamp": "2024-10-28T13:41:19.671878713Z",
   "facts": {
     "companyId": "c49c6381-bac2-4a90-9738-cd358576d68a",


### PR DESCRIPTION
the subtopic field is only used internally by the event service and subscribers cannot see / should not use it. therefore, we remove it from the docu of travel search events