### PR TITLE
Update v4.workflows.markdown

### DIFF
--- a/src/api-reference/expense/expense-report/v4.workflows.markdown
+++ b/src/api-reference/expense/expense-report/v4.workflows.markdown
@@ -15,6 +15,8 @@ The Workflows v4 APIs are used to get information about as well as take action o
 
 Access to this documentation does not provide access to the API.
 
+This API is not supported for the Processor role or expense reports pending the Processor workflow step.
+
 ### <a name="products-editions"></a>Products and Editions
 
 * Concur Expense Professional Edition


### PR DESCRIPTION
I added the following limitation which is not included and it is something that the clients complain a lot:

This API is not supported for the Processor role or expense reports pending the Processor workflow step.

