### PR TITLE
Revert recent change to Expense Report Service documentation

### DIFF
--- a/src/api-reference/expense/expense-report/v4.workflows.markdown
+++ b/src/api-reference/expense/expense-report/v4.workflows.markdown
@@ -15,8 +15,6 @@ The Workflows v4 APIs are used to get information about as well as take action o
 
 Access to this documentation does not provide access to the API.
 
-This API is not supported for the Processor role or expense reports pending the Processor workflow step.
-
 ### <a name="products-editions"></a>Products and Editions
 
 * Concur Expense Professional Edition


### PR DESCRIPTION
Expense Report Service developer here, this recent change by support team is not accurate, multiple of our workflow API's do support actions on a processor step. Only a select few of the API's do not and we already have this specified further down in the documentation.

Recent PR that brought this line in:
https://github.com/SAP-docs/preview.developer.concur.com/pull/1250