### PR TITLE
ERS-31031: Whole lot of documentation cleanup and tying up of loose ends

### DIFF
--- a/src/api-reference/expense/expense-report/v4.allocations.markdown
+++ b/src/api-reference/expense/expense-report/v4.allocations.markdown
@@ -6,7 +6,9 @@ layout: reference
 
 # Allocations v4
 
-The Allocations API can be used to read the allocations that belong to a specific expense on an expense report and modify an allocation on an existing expense in an expense report. This API can be used to change custom field attributes, etc.
+The Allocations API can be used to read the allocations that belong to a specific expense on an expense report and
+modify an allocation on an existing expense in an expense report. This API can be used to change custom field
+attributes, etc.
 
 ## Prior Versions
 
@@ -25,22 +27,24 @@ Access to this documentation does not provide access to the API.
 
 Required Scopes:
 
-|Name|Description|Endpoint|
-|---|---|---|
-|`expense.report.read`|Get information about expense reports.|GET|
-|`expense.report.readwrite`|Read and write expense report headers.        |PATCH|
-|`user.read`|Get User Information, necessary for `userID`.|GET|
+| Name                       | Description                                   | Endpoint |
+|----------------------------|-----------------------------------------------|----------|
+| `expense.report.read`      | Get information about expense reports.        | GET      |
+| `expense.report.readwrite` | Read and write expense report headers.        | PATCH    |
+| `user.read`                | Get User Information, necessary for `userID`. | GET      |
 
 Optional Scope:
 
-|Name|Description|Endpoint|
-|---|---|---|
-|`spend.listitem.read`|Read only access to spend list items `listItemId`.  |GET|
-|`spend.list.read`|Read only access to spend list and category details.| GET|
+| Name                  | Description                                          | Endpoint |
+|-----------------------|------------------------------------------------------|----------|
+| `spend.listitem.read` | Read only access to spend list items `listItemId`.   | GET      |
+| `spend.list.read`     | Read only access to spend list and category details. | GET      |
 
 ## Dependencies <a name="dependencies"></a>
 
-SAP Concur clients must purchase Concur Expense in order to use this API. This API requires the Identity v4 API which is currently only available to approved early access partners. Please contact your SAP Concur representative for more information.
+SAP Concur clients must purchase Concur Expense in order to use this API. This API requires the Identity v4 API which is
+currently only available to approved early access partners. Please contact your SAP Concur representative for more
+information.
 
 ## Access Token Usage <a name="access-token-usage"></a>
 
@@ -64,12 +68,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported value: `TRAVELER` |
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which the expense entry belongs whose allocations are being retrieved.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry whose allocations are being retrieved.|
+| Name          | Type     | Format | Description                                                                                                                                         |
+|---------------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported value: `TRAVELER`, `MANAGER` |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report to which the expense entry belongs whose allocations are being retrieved.                          |
+| `expenseId`   | `string` | -      | **Required** The unique identifier of the expense entry whose allocations are being retrieved.                                                      |
 
 #### Headers
 
@@ -79,8 +83,10 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
-* `concur-correlationid` is a Concur specific custom header used for technical support in the form of a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
+* `concur-correlationid` is a Concur specific custom header used for technical support in the form of
+  a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
 
 ### Response
 
@@ -95,7 +101,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Headers
 
-* `concur-correlationid` is a SAP Concur specific custom header used for technical support in the form of a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
+* `concur-correlationid` is a SAP Concur specific custom header used for technical support in the form of
+  a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
 
 #### Payload
 
@@ -195,12 +202,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this allocation belongs.|
-|`allocationId`|`string`|-|**Required** The unique identifier of the allocation that is being retrieved.|
+| Name           | Type     | Format | Description                                                                                                                                         |
+|----------------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`       | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
+| `contextType`  | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`  |
+| `reportId`     | `string` | -      | **Required** The unique identifier of the report to which this allocation belongs.                                                                  |
+| `allocationId` | `string` | -      | **Required** The unique identifier of the allocation that is being retrieved.                                                                       |
 
 #### Headers
 
@@ -210,8 +217,10 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
-* `concur-correlationid` is a Concur specific custom header used for technical support in the form of a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
+* `concur-correlationid` is a Concur specific custom header used for technical support in the form of
+  a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
 
 ### Response
 
@@ -226,7 +235,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Headers
 
-* `concur-correlationid` is a SAP Concur specific custom header used for technical support in the form of a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
+* `concur-correlationid` is a SAP Concur specific custom header used for technical support in the form of
+  a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
 
 #### Payload
 
@@ -296,12 +306,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this allocation belongs.|
-|`allocationId`|`string`|-|**Required** The unique identifier of the allocation that is being retrieved.|
+| Name           | Type     | Format | Description                                                                                                                                         |
+|----------------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`       | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
+| `contextType`  | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`  |
+| `reportId`     | `string` | -      | **Required** The unique identifier of the report to which this allocation belongs.                                                                  |
+| `allocationId` | `string` | -      | **Required** The unique identifier of the allocation that is being retrieved.                                                                       |
 
 #### Headers
 
@@ -311,8 +321,10 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
-* `concur-correlationid` is a Concur specific custom header used for technical support in the form of a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
+* `concur-correlationid` is a Concur specific custom header used for technical support in the form of
+  a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
 
 #### REST Design Specification
 
@@ -337,7 +349,8 @@ PATCH operations in Expense Reports v4 conform to the JSON Merge Patch specifica
 
 #### Headers
 
-* `concur-correlationid` is a SAP Concur specific custom header used for technical support in the form of a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
+* `concur-correlationid` is a SAP Concur specific custom header used for technical support in the form of
+  a [RFC 4122 A Universally Unique IDentifier (UUID) URN Namespace](https://tools.ietf.org/html/rfc4122)
 
 #### Payload
 
@@ -379,77 +392,77 @@ curl --location --request PATCH 'https://us.api.concursolutions.com/expenserepor
 
 ### <a name="report-allocation-response-schema"></a>ReportAllocationResponse
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`accountCode`|`string`|-|The ledger account code associated with the allocation.|
-|`allocationAmount`|[`Amount`](#amount-schema)|-|The amount of the allocation.|
-|`allocationId`|`string`|-|**Required** The unique identifier of the allocation.|
-|`approvedAmount`|[`Amount`](#amount-schema)|-|The pro-rated amount of the allocation approved for reimbursement based on the approved expense amount.|
-|`claimedAmount`|[`Amount`](#amount-schema)|-|The amount of the allocation requested for reimbursement.|
-|`customData`|[`CustomData`](#custom-data-schema)|-|The details from the `customData` fields. These fields may not have data, depending on the configuration.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense associated with the allocation.|
-|`isPercentEdited`|`boolean`|`true`/`false`|**Required** Whether the allocation percent has been edited.|
-|`isSystemAllocation`|`boolean`|`true`/`false`|**Required** Whether the allocation is a system allocation, usually hidden from the user. If displayed to the user, should be read-only.|
-|`overLimitAccountCode`|`string`|-|The ledger account code associated with the allocation if it exceeds a pre-defined threshold, for example, the user’s travel allowance limit.|
-|`percentage`|`number`|`double`|**Required** The percentage of the total expense that this allocation represents.|
+| Name                   | Type                                | Format         | Description                                                                                                                                   |
+|------------------------|-------------------------------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `accountCode`          | `string`                            | -              | The ledger account code associated with the allocation.                                                                                       |
+| `allocationAmount`     | [`Amount`](#amount-schema)          | -              | The amount of the allocation.                                                                                                                 |
+| `allocationId`         | `string`                            | -              | **Required** The unique identifier of the allocation.                                                                                         |
+| `approvedAmount`       | [`Amount`](#amount-schema)          | -              | The pro-rated amount of the allocation approved for reimbursement based on the approved expense amount.                                       |
+| `claimedAmount`        | [`Amount`](#amount-schema)          | -              | The amount of the allocation requested for reimbursement.                                                                                     |
+| `customData`           | [`CustomData`](#custom-data-schema) | -              | The details from the `customData` fields. These fields may not have data, depending on the configuration.                                     |
+| `expenseId`            | `string`                            | -              | **Required** The unique identifier of the expense associated with the allocation.                                                             |
+| `isPercentEdited`      | `boolean`                           | `true`/`false` | **Required** Whether the allocation percent has been edited.                                                                                  |
+| `isSystemAllocation`   | `boolean`                           | `true`/`false` | **Required** Whether the allocation is a system allocation, usually hidden from the user. If displayed to the user, should be read-only.      |
+| `overLimitAccountCode` | `string`                            | -              | The ledger account code associated with the allocation if it exceeds a pre-defined threshold, for example, the user’s travel allowance limit. |
+| `percentage`           | `number`                            | `double`       | **Required** The percentage of the total expense that this allocation represents.                                                             |
 
 ### <a name="custom-data-schema"></a>CustomData
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|**Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`|
-|`isValid`|`boolean`|`true`/`false`|Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true`|
-|`value`|`string`|-|The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters|
+| Name      | Type      | Format         | Description                                                                                                                                                                                          |
+|-----------|-----------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`      | `string`  | -              | **Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`                                                                                                              |
+| `isValid` | `boolean` | `true`/`false` | Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true` |
+| `value`   | `string`  | -              | The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters                      |
 
 ### <a name="amount-schema"></a>Amount
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`currencyCode`|`string`|-|**Required** The 3-letter ISO 4217 currency code for the expense report currency, based on the user's assigned reimbursement currency when the report was created. Examples: `USD` - US dollars; `BRL` - Brazilian real; `CAD` - Canadian dollar; `CHF` - Swiss franc; `EUR` - Euro; `GBO` - Pound sterling; `HKD` - Hong Kong dollar; `INR` - Indian rupee; `MXN` - Mexican peso; `NOK` - Norwegian krone; `SEK` - Swedish krona|
-|`value`|`number`|`double`|**Required** The amount in the defined currency.|
+| Name           | Type     | Format   | Description                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|----------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `currencyCode` | `string` | -        | **Required** The 3-letter ISO 4217 currency code for the expense report currency, based on the user's assigned reimbursement currency when the report was created. Examples: `USD` - US dollars; `BRL` - Brazilian real; `CAD` - Canadian dollar; `CHF` - Swiss franc; `EUR` - Euro; `GBO` - Pound sterling; `HKD` - Hong Kong dollar; `INR` - Indian rupee; `MXN` - Mexican peso; `NOK` - Norwegian krone; `SEK` - Swedish krona |
+| `value`        | `number` | `double` | **Required** The amount in the defined currency.                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ### <a name="update-report-allocation-schema"></a>UpdateReportAllocation
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`allocation`|[`UpdateAllocation`](#allocation-schema)|-|**Required** This is an allocation custom data object to be updated.|
-|`expenseIds`|`string`|-|**Required** This is an array of unique identifiers of expenses within this report that are being updated.|
+| Name         | Type                                     | Format | Description                                                                                                |
+|--------------|------------------------------------------|--------|------------------------------------------------------------------------------------------------------------|
+| `allocation` | [`UpdateAllocation`](#allocation-schema) | -      | **Required** This is an allocation custom data object to be updated.                                       |
+| `expenseIds` | `string`                                 | -      | **Required** This is an array of unique identifiers of expenses within this report that are being updated. |
 
 ### <a name="update-allocation-schema"></a>UpdateAllocation
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`customData`|[CustomData](#custom-data-schema)|-|The details from the `customData` fields. These fields may not have data, depending on the configuration.|
+| Name         | Type                              | Format | Description                                                                                               |
+|--------------|-----------------------------------|--------|-----------------------------------------------------------------------------------------------------------|
+| `customData` | [CustomData](#custom-data-schema) | -      | The details from the `customData` fields. These fields may not have data, depending on the configuration. |
 
 ### <a name="link-schema"></a>Link
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`deprecation`|`string`|-|-|
-|`href`|`string`|-|**Required** The URL of the related `HATEOAS` link that you can use for subsequent calls.|
-|`hreflang`|`string`|-|-|
-|`isTemplated`|`boolean`|`true`/`false`|**Required** Whether the `href` is parameterized.|
-|`media`|`string`|-|-|
-|`method`|`string`|-|**Required** The HTTP method required for the related call.|
-|`rel`|`string`|-|**Required** The link relationship that describes how the `href` relates to the API call.|
-|`title`|`string`|-|-|
-|`type`|`string`|-|-|
+| Name          | Type      | Format         | Description                                                                               |
+|---------------|-----------|----------------|-------------------------------------------------------------------------------------------|
+| `deprecation` | `string`  | -              | -                                                                                         |
+| `href`        | `string`  | -              | **Required** The URL of the related `HATEOAS` link that you can use for subsequent calls. |
+| `hreflang`    | `string`  | -              | -                                                                                         |
+| `isTemplated` | `boolean` | `true`/`false` | **Required** Whether the `href` is parameterized.                                         |
+| `media`       | `string`  | -              | -                                                                                         |
+| `method`      | `string`  | -              | **Required** The HTTP method required for the related call.                               |
+| `rel`         | `string`  | -              | **Required** The link relationship that describes how the `href` relates to the API call. |
+| `title`       | `string`  | -              | -                                                                                         |
+| `type`        | `string`  | -              | -                                                                                         |
 
 ### <a name="error-message-schema"></a>ErrorMessage
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`errorId`|`string`|-|The unique identifier of the error associated with the response.|
-|`errorMessage`|`string`|-|**Required** The detailed error message.|
-|`httpStatus`|`string`|-|**Required** The http response code and phrase for the response.|
-|`path`|`string`|-|**Required** The URI of the attempted request.|
-|`timestamp`|`string`|`date-time`|**Required** The time when the error was captured.|
-|`validationErrors`|[`ValidationError`](#validation-error-schema)|-|The validation error messages.|
+| Name               | Type                                          | Format      | Description                                                      |
+|--------------------|-----------------------------------------------|-------------|------------------------------------------------------------------|
+| `errorId`          | `string`                                      | -           | The unique identifier of the error associated with the response. |
+| `errorMessage`     | `string`                                      | -           | **Required** The detailed error message.                         |
+| `httpStatus`       | `string`                                      | -           | **Required** The http response code and phrase for the response. |
+| `path`             | `string`                                      | -           | **Required** The URI of the attempted request.                   |
+| `timestamp`        | `string`                                      | `date-time` | **Required** The time when the error was captured.               |
+| `validationErrors` | [`ValidationError`](#validation-error-schema) | -           | The validation error messages.                                   |
 
 ### <a name="validation-errors-schema"></a>ValidationError
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|The ID of the validation error.|
-|`message`|`string`|-|The detailed message of the validation error.|
-|`source`|`string`|-|The type of validation which failed.|
+| Name      | Type     | Format | Description                                   |
+|-----------|----------|--------|-----------------------------------------------|
+| `id`      | `string` | -      | The ID of the validation error.               |
+| `message` | `string` | -      | The detailed message of the validation error. |
+| `source`  | `string` | -      | The type of validation which failed.          |

--- a/src/api-reference/expense/expense-report/v4.comments.markdown
+++ b/src/api-reference/expense/expense-report/v4.comments.markdown
@@ -7,7 +7,9 @@ layout: reference
 
 The Comments v4 API POSTs, GETs, PUTs, and DELETEs comments associated with an expense or a report.
 
-Comments are typically added to an expense or a report to add additional information about an expense or a report. For example, a comment may highlight spending that is out of policy or a comment may be added to justify a particular expenditure.
+Comments are typically added to an expense or a report to add additional information about an expense or a report. For
+example, a comment may highlight spending that is out of policy or a comment may be added to justify a particular
+expenditure.
 
 ## <a name="prior-versions"></a>Prior Versions
 
@@ -24,7 +26,8 @@ Access to this documentation does not provide access to the API.
 
 ## <a name="dependencies"></a>Dependencies
 
-SAP Concur clients must purchase Concur Expense in order to use this API. User based API requires the Identity v4 API . Please contact your SAP Concur representative for more information.
+SAP Concur clients must purchase Concur Expense in order to use this API. User based API requires the Identity v4 API .
+Please contact your SAP Concur representative for more information.
 
 ## <a name="access-token-usage"></a>Access Token Usage
 
@@ -49,13 +52,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
-|`includeAllComments`|`boolean`|true or false|Return all the comments that are present on the report at all levels. Default value: false|
-
+| Name                 | Type      | Format        | Description                                                                                                                                                   |
+|----------------------|-----------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`             | `string`  | -             | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.               |
+| `contextType`        | `string`  | -             | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `MANAGER`, `PROXY` |
+| `reportId`           | `string`  | -             | **Required** The unique identifier of the report that is being read.                                                                                          |
+| `includeAllComments` | `boolean` | true or false | Return all the comments that are present on the report at all levels. Default value: false                                                                    |
 
 #### Headers
 
@@ -65,7 +67,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 ### Response
 
@@ -77,7 +80,6 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [403 Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -95,7 +97,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 
 #### Response
 
-
 ```shell
 200 OK
 
@@ -103,14 +104,12 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
   {
     "comment": "This is an expense report for office supplies",
     "author": {
-      "firstName": "Concur",
-      "lastName": "Administrator",
-      "middleInitial": ""
+      "employeeId": "string",
+      "employeeUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
     },
     "createdForEmployee": {
-      "firstName": "Tester",
-      "lastName": "Insert",
-      "middleInitial": "A"
+      "employeeId": "string",
+      "employeeUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
     },
     "createdForEmployeeId": "32c2fcc3-b2e8-4907-9672-5b3f49b1c643",
     "creationDate": "2021-03-17T22:29:50.090Z",
@@ -141,11 +140,10 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
-|`includeAllComments`|`boolean`|true or false|Return all the comments that are present on the report at all levels. Default value: false|
-
+| Name                 | Type      | Format        | Description                                                                                |
+|----------------------|-----------|---------------|--------------------------------------------------------------------------------------------|
+| `reportId`           | `string`  | -             | **Required** The unique identifier of the report that is being read.                       |
+| `includeAllComments` | `boolean` | true or false | Return all the comments that are present on the report at all levels. Default value: false |
 
 #### Headers
 
@@ -155,7 +153,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -166,7 +165,6 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 * [401 Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -184,7 +182,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 
 #### Response
 
-
 ```shell
 200 OK
 
@@ -192,14 +189,12 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
   {
     "comment": "This is an expense report for office supplies",
     "author": {
-      "firstName": "Concur",
-      "lastName": "Administrator",
-      "middleInitial": ""
+      "employeeId": "string",
+      "employeeUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
     },
     "createdForEmployee": {
-      "firstName": "Tester",
-      "lastName": "Insert",
-      "middleInitial": "A"
+      "employeeId": "string",
+      "employeeUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
     },
     "createdForEmployeeId": "32c2fcc3-b2e8-4907-9672-5b3f49b1c643",
     "creationDate": "2021-03-17T22:29:50.090Z",
@@ -210,6 +205,7 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
   }
 ]
 ```
+
 ## <a name="post-report-header-comments"></a>Post Report Header Comment
 
 Creates a new comment for the specified report.
@@ -228,11 +224,11 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
+| Name          | Type     | Format | Description                                                                                                                                                   |
+|---------------|----------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.               |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `MANAGER`, `PROXY` |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report that is being read.                                                                                          |
 
 #### Headers
 
@@ -242,15 +238,14 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 #### Payload
 
 * [Comment](#comment-schema)
 
 ### Response
-
-
 
 #### Status Codes
 
@@ -260,7 +255,6 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [403 Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -281,7 +275,6 @@ curl --location --request 'POST' \
 ```
 
 #### Response
-
 
 ```shell
 201 Created
@@ -309,9 +302,9 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
+| Name       | Type     | Format | Description                                                          |
+|------------|----------|--------|----------------------------------------------------------------------|
+| `reportId` | `string` | -      | **Required** The unique identifier of the report that is being read. |
 
 #### Headers
 
@@ -321,15 +314,14 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 #### Payload
 
 * [Comment](#comment-schema)
 
 ### Response
-
-
 
 #### Status Codes
 
@@ -338,7 +330,6 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 * [401 Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -359,7 +350,6 @@ curl --location --request 'POST' \
 ```
 
 #### Response
-
 
 ```shell
 201 Created
@@ -387,11 +377,11 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
+| Name          | Type     | Format | Description                                                                                                                                        |
+|---------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report that is being read.                                                                               |
 
 #### Headers
 
@@ -401,7 +391,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 ### Payload
 
@@ -417,7 +408,6 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [403 Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -438,7 +428,6 @@ curl --location --request 'PUT' \
 ```
 
 #### Response
-
 
 ```shell
 200 OK
@@ -466,9 +455,9 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
+| Name       | Type     | Format | Description                                                          |
+|------------|----------|--------|----------------------------------------------------------------------|
+| `reportId` | `string` | -      | **Required** The unique identifier of the report that is being read. |
 
 #### Headers
 
@@ -478,7 +467,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Payload
 
@@ -493,7 +483,6 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 * [401 Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -514,7 +503,6 @@ curl --location --request 'PUT' \
 ```
 
 #### Response
-
 
 ```shell
 200 OK
@@ -542,11 +530,11 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
+| Name          | Type     | Format | Description                                                                                                                                        |
+|---------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report that is being read.                                                                               |
 
 #### Headers
 
@@ -556,7 +544,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 ### Response
 
@@ -568,7 +557,6 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [403 Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 ### Example
 
@@ -582,7 +570,6 @@ curl --location --request 'DELETE' \
 ```
 
 #### Response
-
 
 ```shell
 204 No Content
@@ -606,9 +593,9 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
+| Name       | Type     | Format | Description                                                          |
+|------------|----------|--------|----------------------------------------------------------------------|
+| `reportId` | `string` | -      | **Required** The unique identifier of the report that is being read. |
 
 #### Headers
 
@@ -618,7 +605,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -629,7 +617,6 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/comments
 * [401 Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 ### Example
 
@@ -644,11 +631,9 @@ curl --location --request 'DELETE' \
 
 #### Response
 
-
 ```shell
 204 No Content
 ```
-
 
 ## <a name="retrieve-expense-comments"></a>Retrieve Expense Comments
 
@@ -669,12 +654,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry to which the comments belong.|
+| Name          | Type     | Format | Description                                                                                                                                        |
+|---------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs.                                                              |
+| `expenseId`   | `string` | -      | **Required** The unique identifier of the expense entry to which the comments belong.                                                              |
 
 #### Headers
 
@@ -684,7 +669,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 ### Response
 
@@ -713,7 +699,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 
 #### Response
 
-
 ```shell
 200 OK
 
@@ -721,14 +706,12 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
     {
         "comment": "This expense is allowed due to the pandemic",
         "author": {
-            "firstName": "Concur",
-            "lastName": "Administrator",
-            "middleInitial": ""
+          "employeeId": "string",
+          "employeeUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
         },
         "createdForEmployee": {
-            "firstName": "Tester",
-            "lastName": "Insert",
-            "middleInitial": "A"
+          "employeeId": "string",
+          "employeeUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
         },
         "createdForEmployeeId": "32c2fcc3-b2e8-4907-9672-5b3f49b1c643",
         "creationDate": "2021-03-17T23:05:40.340Z",
@@ -759,10 +742,10 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry to which the comments belong.|
+| Name        | Type     | Format | Description                                                                           |
+|-------------|----------|--------|---------------------------------------------------------------------------------------|
+| `reportId`  | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs. |
+| `expenseId` | `string` | -      | **Required** The unique identifier of the expense entry to which the comments belong. |
 
 #### Headers
 
@@ -772,7 +755,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -800,7 +784,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 
 #### <a name="expense-comments-response"></a> Expense Comments Response
 
-
 ```shell
 200 OK
 
@@ -808,14 +791,12 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
     {
         "comment": "This expense is allowed due to the pandemic",
         "author": {
-            "firstName": "Concur",
-            "lastName": "Administrator",
-            "middleInitial": ""
+              "employeeId": "string",
+              "employeeUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
         },
         "createdForEmployee": {
-            "firstName": "Tester",
-            "lastName": "Insert",
-            "middleInitial": "A"
+              "employeeId": "string",
+              "employeeUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
         },
         "createdForEmployeeId": "32c2fcc3-b2e8-4907-9672-5b3f49b1c643",
         "creationDate": "2021-03-17T23:05:40.340Z",
@@ -845,12 +826,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry to which the comments belong.|
+| Name          | Type     | Format | Description                                                                                                                                        |
+|---------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs.                                                              |
+| `expenseId`   | `string` | -      | **Required** The unique identifier of the expense entry to which the comments belong.                                                              |
 
 #### Headers
 
@@ -860,15 +841,14 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 #### Payload
 
 * [Comment](#comment-schema)
 
-
 ### Response
-
 
 #### Status Codes
 
@@ -898,7 +878,6 @@ curl --location --request POST 'https://us.api.concursolutions.com/expensereport
 
 #### Response
 
-
 ```shell
 201 Created
 
@@ -925,10 +904,10 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry to which the comments belong.|
+| Name        | Type     | Format | Description                                                                           |
+|-------------|----------|--------|---------------------------------------------------------------------------------------|
+| `reportId`  | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs. |
+| `expenseId` | `string` | -      | **Required** The unique identifier of the expense entry to which the comments belong. |
 
 #### Headers
 
@@ -938,12 +917,12 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 #### Payload
 
 * [Comment](#comment-schema)
-
 
 ### Response
 
@@ -974,7 +953,6 @@ curl --location --request POST 'https://us.api.concursolutions.com/expensereport
 
 #### Response
 
-
 ```shell
 201 Created
 
@@ -1001,12 +979,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry to which the comments belong.|
+| Name          | Type     | Format | Description                                                                                                                                        |
+|---------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs.                                                              |
+| `expenseId`   | `string` | -      | **Required** The unique identifier of the expense entry to which the comments belong.                                                              |
 
 #### Headers
 
@@ -1016,12 +994,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 #### Payload
 
 * [Comment](#comment-schema)
-
 
 ### Response
 
@@ -1053,7 +1031,6 @@ curl --location --request PUT 'https://us.api.concursolutions.com/expensereports
 
 #### Response
 
-
 ```shell
 200 OK
 
@@ -1061,8 +1038,6 @@ curl --location --request PUT 'https://us.api.concursolutions.com/expensereports
   "uri": "https://us.api.concursolutions.com/expensereports/v4/users/750524a2-907b-4dde-9fec-d038ab043f53/context/TRAVELER/reports/E364C14BAEEA4BE5922C/expenses/36CBAA8D4ADE6C46BB587C05293405DC/comments"
 }
 ```
-
-
 
 ## <a name="update-expense-comments"></a>Update Expense Comments Using System User
 
@@ -1082,10 +1057,10 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry to which the comments belong.|
+| Name        | Type     | Format | Description                                                                           |
+|-------------|----------|--------|---------------------------------------------------------------------------------------|
+| `reportId`  | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs. |
+| `expenseId` | `string` | -      | **Required** The unique identifier of the expense entry to which the comments belong. |
 
 #### Headers
 
@@ -1095,12 +1070,12 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 #### Payload
 
 * [Comment](#comment-schema)
-
 
 ### Response
 
@@ -1131,7 +1106,6 @@ curl --location --request PUT 'https://us.api.concursolutions.com/expensereports
 
 #### Response
 
-
 ```shell
 200 OK
 
@@ -1139,8 +1113,6 @@ curl --location --request PUT 'https://us.api.concursolutions.com/expensereports
   "uri": "https://us.api.concursolutions.com/expensereports/v4/reports/764428DD6A664AF0BFCB/expenses/84FCBB92BD4E5342B849DAC29FD163A1/comments"
 }
 ```
-
-
 
 ## <a name="delete-report-header-comments"></a>Delete Expense Comments
 
@@ -1160,12 +1132,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry to which the comments belong.|
+| Name          | Type     | Format | Description                                                                                                                                        |
+|---------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs.                                                              |
+| `expenseId`   | `string` | -      | **Required** The unique identifier of the expense entry to which the comments belong.                                                              |
 
 #### Headers
 
@@ -1175,7 +1147,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 ### Response
 
@@ -1187,7 +1160,6 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [403 Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 ### Example
 
@@ -1201,7 +1173,6 @@ curl --location --request 'DELETE' \
 ```
 
 #### Response
-
 
 ```shell
 204 No Content
@@ -1225,10 +1196,10 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry to which the comments belong.|
+| Name        | Type     | Format | Description                                                                           |
+|-------------|----------|--------|---------------------------------------------------------------------------------------|
+| `reportId`  | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs. |
+| `expenseId` | `string` | -      | **Required** The unique identifier of the expense entry to which the comments belong. |
 
 #### Headers
 
@@ -1238,7 +1209,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -1249,7 +1221,6 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [401 Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 ### Example
 
@@ -1264,77 +1235,73 @@ curl --location --request 'DELETE' \
 
 #### Response
 
-
 ```shell
 204 No Content
 ```
-
 
 ## <a name="schema"></a>Schema
 
 ### <a name="report-header-comments-response-schema"></a> Report Header Comments Response
 
-Name|Type|Format|Description
----|---|---|---
-`commentDetails`|`array`|[`commentDetails`](#comment-details)|A key linking to another schema for the format.
+| Name             | Type    | Format                               | Description                                     |
+|------------------|---------|--------------------------------------|-------------------------------------------------|
+| `commentDetails` | `array` | [`commentDetails`](#comment-details) | A key linking to another schema for the format. |
 
 ### <a name="expense-comments-response-schema"></a> Expense Comments
 
-Name|Type|Format|Description
----|---|---|---
-`commentDetails`|`array`|[`commentDetails`](#comment-details)|A key linking to another schema for the format.
+| Name             | Type    | Format                               | Description                                     |
+|------------------|---------|--------------------------------------|-------------------------------------------------|
+| `commentDetails` | `array` | [`commentDetails`](#comment-details) | A key linking to another schema for the format. |
 
 ### <a name="comment-schema"></a> Comment
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`comment`|`string`|-|The comments input on the report/expense by all users.|
-
+| Name      | Type     | Format | Description                                            |
+|-----------|----------|--------|--------------------------------------------------------|
+| `comment` | `string` | -      | The comments input on the report/expense by all users. |
 
 ### <a name="comment-save-response-schema"></a> Comment Save Response
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`uri`|`string`|-|The URI of the comment.|
+| Name  | Type     | Format | Description             |
+|-------|----------|--------|-------------------------|
+| `uri` | `string` | -      | The URI of the comment. |
 
 #### <a name="comment-details"></a>commentDetails
 
-Name|Type|Format|Description
----|---|--|---
-`author`|[`Employee`](#employee-schema)|-|**Required** The comment author's name.
-`comment`|`string`|-|**Required** The comments input on the report by all users.
-`createdForEmployee`|[`Employee`](#employee-schema)|-|**Required** The name of the employee the comment was created on behalf of. This would differ from the comment author only in the case of delegates creating the comment.
-`createdForEmployeeId`|`string`|-|**Required** The unique identifier of the employee the comment was created on behalf of. This would differ from the comment author only in the case of delegates creating the comment.
-`creationDate`|`string`|`YYYY-MM-DDTHH:mm:ssZ.SSS'Z'`|**Required** The UTC datetime when the comment was created on the report or expense.
-`expenseId`|`string`|-|**Required** The unique identifier of the expense.
-`isAuditorComment`|`boolean`|`true`/`false`|**Required** If `true`, this attribute represents whether this comment has been authored by an auditor.
-`isLatest`|`boolean`|`true`/`false`|**Required** If `true`, this attribute represents the latest comment by the user.
-`stepInstanceId`|`string`|-|The unique identifier of the step instance.
+| Name                   | Type                           | Format                        | Description                                                                                                                                                                            |
+|------------------------|--------------------------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `author`               | [`Employee`](#employee-schema) | -                             | **Required** The comment author's name.                                                                                                                                                |
+| `comment`              | `string`                       | -                             | **Required** The comments input on the report by all users.                                                                                                                            |
+| `createdForEmployee`   | [`Employee`](#employee-schema) | -                             | **Required** The name of the employee the comment was created on behalf of. This would differ from the comment author only in the case of delegates creating the comment.              |
+| `createdForEmployeeId` | `string`                       | -                             | **Required** The unique identifier of the employee the comment was created on behalf of. This would differ from the comment author only in the case of delegates creating the comment. |
+| `creationDate`         | `string`                       | `YYYY-MM-DDTHH:mm:ssZ.SSS'Z'` | **Required** The UTC datetime when the comment was created on the report or expense.                                                                                                   |
+| `expenseId`            | `string`                       | -                             | **Required** The unique identifier of the expense.                                                                                                                                     |
+| `isAuditorComment`     | `boolean`                      | `true`/`false`                | **Required** If `true`, this attribute represents whether this comment has been authored by an auditor.                                                                                |
+| `isLatest`             | `boolean`                      | `true`/`false`                | **Required** If `true`, this attribute represents the latest comment by the user.                                                                                                      |
+| `stepInstanceId`       | `string`                       | -                             | The unique identifier of the step instance.                                                                                                                                            |
 
 ### <a name="employee-schema"></a>Employee
 
-Name|Type|Format|Description
----|---|---|---
-`firstName`|`string`|-|First name of the employee.
-`lastName`|`string`|-|Last name of the employee.
-`middleInitial`|`string`|-|Middle initial of the employee.
+| Name           | Type     | Format | Description                                                                        |
+|----------------|----------|--------|------------------------------------------------------------------------------------|
+| `employeeId`   | `string` | -      | Unique identifier of the employee that can be referenced in external systems.      |
+| `employeeUuid` | `string` | -      | UUID of the employee used to identify the employee within internal concur systems. |
 
 ### <a name="error-message-schema"></a>Error Message
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`customResponseData`|`object`|-|The custom parameters related to error.|
-|`errorId`|`string`|-|The unique identifier of the error associated with the response.|
-|`errorMessage`|`string`|-|**Required** The detailed error message.|
-|`httpStatus`|`string`|-|**Required** The http response code and phrase for the response.|
-|`path`|`string`|-|**Required** The URI of the attempted request.|
-|`timestamp`|`string`|`date-time`|**Required** The time when the error was captured.|
-|`validationErrors`|[`ValidationError`](#validation-error-schema)|-|The validation error messages.|
+| Name                 | Type                                          | Format      | Description                                                      |
+|----------------------|-----------------------------------------------|-------------|------------------------------------------------------------------|
+| `customResponseData` | `object`                                      | -           | The custom parameters related to error.                          |
+| `errorId`            | `string`                                      | -           | The unique identifier of the error associated with the response. |
+| `errorMessage`       | `string`                                      | -           | **Required** The detailed error message.                         |
+| `httpStatus`         | `string`                                      | -           | **Required** The http response code and phrase for the response. |
+| `path`               | `string`                                      | -           | **Required** The URI of the attempted request.                   |
+| `timestamp`          | `string`                                      | `date-time` | **Required** The time when the error was captured.               |
+| `validationErrors`   | [`ValidationError`](#validation-error-schema) | -           | The validation error messages.                                   |
 
 ### <a name="validation-errors-schema"></a>Validation Error
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|The ID of the validation error.|
-|`message`|`string`|-|The detailed message of the validation error.|
-|`source`|`string`|-|The type of validation which failed.|
+| Name      | Type     | Format | Description                                   |
+|-----------|----------|--------|-----------------------------------------------|
+| `id`      | `string` | -      | The ID of the validation error.               |
+| `message` | `string` | -      | The detailed message of the validation error. |
+| `source`  | `string` | -      | The type of validation which failed.          |

--- a/src/api-reference/expense/expense-report/v4.exceptions.markdown
+++ b/src/api-reference/expense/expense-report/v4.exceptions.markdown
@@ -22,14 +22,16 @@ Access to this documentation does not provide access to the API.
 
 ## <a name="scope-usage"></a>Scope Usage
 
-|Name|Description|Endpoint|
-|---|-----------|---|
-|`expense.report.read`|Get information about exceptions(s).|GET|
-|`expense.report.readwrite`|Read, write, and delete exception(s).|GET, PUT, DELETE|
+| Name                       | Description                           | Endpoint         |
+|----------------------------|---------------------------------------|------------------|
+| `expense.report.read`      | Get information about exceptions(s).  | GET              |
+| `expense.report.readwrite` | Read, write, and delete exception(s). | GET, PUT, DELETE |
 
 ## Dependencies <a name="dependencies"></a>
 
-SAP Concur clients must purchase Concur Expense in order to use this API. User based API requires the use of the [Identity v4 API](/api-reference/profile/v4.identity.html). Please contact your SAP Concur representative for more information.
+SAP Concur clients must purchase Concur Expense in order to use this API. User based API requires the use of
+the [Identity v4 API](/api-reference/profile/v4.identity.html). Please contact your SAP Concur representative for more
+information.
 
 ## Access Token Usage <a name="access-token-usage"></a>
 
@@ -54,13 +56,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
-|`excludeExpenses`|`boolean`|true or false|Include only exceptions for the report header. Default value: false|
-
+| Name              | Type      | Format        | Description                                                                                                                                        |
+|-------------------|-----------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`          | `string`  | -             | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
+| `contextType`     | `string`  | -             | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
+| `reportId`        | `string`  | -             | **Required** The unique identifier of the report that is being read.                                                                               |
+| `excludeExpenses` | `boolean` | true or false | Include only exceptions for the report header. Default value: false                                                                                |
 
 #### Headers
 
@@ -70,7 +71,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 ### Response
 
@@ -82,7 +84,6 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [403 Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -99,7 +100,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 ```
 
 #### Response
-
 
 ```shell
 200 OK
@@ -154,11 +154,10 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/exceptions
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
-|`excludeExpenses`|`boolean`|true or false|Include only exceptions for the report header. Default value: false|
-
+| Name              | Type      | Format        | Description                                                          |
+|-------------------|-----------|---------------|----------------------------------------------------------------------|
+| `reportId`        | `string`  | -             | **Required** The unique identifier of the report that is being read. |
+| `excludeExpenses` | `boolean` | true or false | Include only exceptions for the report header. Default value: false  |
 
 #### Headers
 
@@ -168,7 +167,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/exceptions
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -179,7 +179,6 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/exceptions
 * [401 Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -196,7 +195,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 ```
 
 #### Response
-
 
 ```shell
 200 OK
@@ -250,9 +248,9 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/exceptions
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report.|
+| Name       | Type     | Format | Description                                       |
+|------------|----------|--------|---------------------------------------------------|
+| `reportId` | `string` | -      | **Required** The unique identifier of the report. |
 
 #### Headers
 
@@ -262,7 +260,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/exceptions
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 #### Payload
 
@@ -317,10 +316,10 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/exceptions/{excepti
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report.|
-|`exceptionCode`| `string` |-| **Required** The code for the exception.|
+| Name            | Type     | Format | Description                                       |
+|-----------------|----------|--------|---------------------------------------------------|
+| `reportId`      | `string` | -      | **Required** The unique identifier of the report. |
+| `exceptionCode` | `string` | -      | **Required** The code for the exception.          |
 
 #### Headers
 
@@ -330,7 +329,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/exceptions/{excepti
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -378,14 +378,13 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-| **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
-|`contextType`|`string`|-| **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
-|`reportId`|`string`|-| **Required** The unique identifier of the report that is being read.                                                                               |
-|`expenseId`|`string`|-| **Required** The unique identifier of the expense entry to which the exceptions belong.                                                            |
-|`excludeItemizations`|`boolean`|true or false| Include only exceptions for non-itemized and parent expenses. Default value: false                                                                 |
-
+| Name                  | Type      | Format        | Description                                                                                                                                                  |
+|-----------------------|-----------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`              | `string`  | -             | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.              |
+| `contextType`         | `string`  | -             | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `MANAGER`, PROXY` |
+| `reportId`            | `string`  | -             | **Required** The unique identifier of the report that is being read.                                                                                         |
+| `expenseId`           | `string`  | -             | **Required** The unique identifier of the expense entry to which the exceptions belong.                                                                      |
+| `excludeItemizations` | `boolean` | true or false | Include only exceptions for non-itemized and parent expenses. Default value: false                                                                           |
 
 #### Headers
 
@@ -395,7 +394,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 ### Response
 
@@ -407,7 +407,6 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [403 Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -424,7 +423,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 ```
 
 #### Response
-
 
 ```shell
 200 OK
@@ -470,12 +468,11 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-| **Required** The unique identifier of the report that is being read.                                                                               |
-|`expenseId`|`string`|-| **Required** The unique identifier of the expense entry to which the exceptions belong.                                                            |
-|`excludeItemizations`|`boolean`|true or false| Include only exceptions for non-itemized and parent expenses. Default value: false                                                                 |
-
+| Name                  | Type      | Format        | Description                                                                             |
+|-----------------------|-----------|---------------|-----------------------------------------------------------------------------------------|
+| `reportId`            | `string`  | -             | **Required** The unique identifier of the report that is being read.                    |
+| `expenseId`           | `string`  | -             | **Required** The unique identifier of the expense entry to which the exceptions belong. |
+| `excludeItemizations` | `boolean` | true or false | Include only exceptions for non-itemized and parent expenses. Default value: false      |
 
 #### Headers
 
@@ -485,7 +482,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -496,7 +494,6 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [401 Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -557,10 +554,10 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report.|
-|`expenseId`|`string`|-| **Required** The unique identifier of the expense entry.                                                            |
+| Name        | Type     | Format | Description                                              |
+|-------------|----------|--------|----------------------------------------------------------|
+| `reportId`  | `string` | -      | **Required** The unique identifier of the report.        |
+| `expenseId` | `string` | -      | **Required** The unique identifier of the expense entry. |
 
 #### Headers
 
@@ -570,7 +567,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 #### Payload
 
@@ -625,11 +623,11 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report.|
-|`expenseId`|`string`|-| **Required** The unique identifier of the expense entry.                                                            |
-|`exceptionCode`| `string` |-| **Required** The code for the exception.|
+| Name            | Type     | Format | Description                                              |
+|-----------------|----------|--------|----------------------------------------------------------|
+| `reportId`      | `string` | -      | **Required** The unique identifier of the report.        |
+| `expenseId`     | `string` | -      | **Required** The unique identifier of the expense entry. |
+| `exceptionCode` | `string` | -      | **Required** The code for the exception.                 |
 
 #### Headers
 
@@ -639,7 +637,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -687,14 +686,13 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format| Description|
-|---|---|---|---|
-|`userID`|`string`|-| **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-| **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-| **Required** The unique identifier of the report that is being read.|
-|`expenseId`|`string`|-| **Required** The unique identifier of the expense entry to which the exceptions belong.|
-|`allocationId`|`string`|-| **Required** The unique identifier of the expense allocation to which the exceptions belong.|
-
+| Name           | Type     | Format | Description                                                                                                                                        |
+|----------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`       | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
+| `contextType`  | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
+| `reportId`     | `string` | -      | **Required** The unique identifier of the report that is being read.                                                                               |
+| `expenseId`    | `string` | -      | **Required** The unique identifier of the expense entry to which the exceptions belong.                                                            |
+| `allocationId` | `string` | -      | **Required** The unique identifier of the expense allocation to which the exceptions belong.                                                       |
 
 #### Headers
 
@@ -704,7 +702,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the user access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the user access token.
 
 ### Response
 
@@ -716,7 +715,6 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [403 Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -733,7 +731,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 ```
 
 #### Response
-
 
 ```shell
 200 OK
@@ -770,12 +767,11 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-| **Required** The unique identifier of the report that is being read.                                                                               |
-|`expenseId`|`string`|-| **Required** The unique identifier of the expense entry to which the exceptions belong.                                                            |
-|`allocationId`|`string`|-| **Required** The unique identifier of the expense allocation to which the exceptions belong.                                                       |
-
+| Name           | Type     | Format | Description                                                                                  |
+|----------------|----------|--------|----------------------------------------------------------------------------------------------|
+| `reportId`     | `string` | -      | **Required** The unique identifier of the report that is being read.                         |
+| `expenseId`    | `string` | -      | **Required** The unique identifier of the expense entry to which the exceptions belong.      |
+| `allocationId` | `string` | -      | **Required** The unique identifier of the expense allocation to which the exceptions belong. |
 
 #### Headers
 
@@ -785,7 +781,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -796,7 +793,6 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [401 Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)
 * [404 Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
 * [500 Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
-
 
 #### Payload
 
@@ -813,7 +809,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 ```
 
 #### Response
-
 
 ```shell
 200 OK
@@ -849,12 +844,11 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report.|
-|`expenseId`|`string`|-| **Required** The unique identifier of the expense entry.|
-|`allocationId`|`string`|-| **Required** The unique identifier of the expense allocation to which the exceptions belong.                                                       |
-
+| Name           | Type     | Format | Description                                                                                  |
+|----------------|----------|--------|----------------------------------------------------------------------------------------------|
+| `reportId`     | `string` | -      | **Required** The unique identifier of the report.                                            |
+| `expenseId`    | `string` | -      | **Required** The unique identifier of the expense entry.                                     |
+| `allocationId` | `string` | -      | **Required** The unique identifier of the expense allocation to which the exceptions belong. |
 
 #### Headers
 
@@ -864,7 +858,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 #### Payload
 
@@ -919,12 +914,12 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report.|
-|`expenseId`|`string`|-| **Required** The unique identifier of the expense entry.|
-|`allocationId`|`string`|-| **Required** The unique identifier of the expense allocation to which the exceptions belong.|
-|`exceptionCode`| `string` |-| **Required** The code for the exception.|
+| Name            | Type     | Format | Description                                                                                  |
+|-----------------|----------|--------|----------------------------------------------------------------------------------------------|
+| `reportId`      | `string` | -      | **Required** The unique identifier of the report.                                            |
+| `expenseId`     | `string` | -      | **Required** The unique identifier of the expense entry.                                     |
+| `allocationId`  | `string` | -      | **Required** The unique identifier of the expense allocation to which the exceptions belong. |
+| `exceptionCode` | `string` | -      | **Required** The code for the exception.                                                     |
 
 #### Headers
 
@@ -934,7 +929,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the company access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the company access token.
 
 ### Response
 
@@ -967,41 +963,39 @@ curl --location --request 'DELETE' \
 
 ### <a name="exceptions-response-schema"></a> Exceptions Response
 
-|Name|Type|Format| Description|
-|---|----|---|---|
-|`exceptionCode`| `string` |-| **Required** The unique identifier of the exception type.|
-|`exceptionVisibility`| `string` |-| **Required** The visibility of the exception. Possible values: 'ALL' - The exception is visible to the Traveler, Approver, and Processor, 'APPROVER_PROCESSOR' - The exception is visible only to the Approver and Processor, 'PROCESSOR' - The exception is visible only to the Processor.|
-|`isBlocking`| `boolean` |`true`/`false`| **Required** Whether the exception will prevent the report from being submitted.|
-|`message`| `string` |-| Description of the exception, in the user's language.|
-|`allocationId`| `string` |-| The unique identifier of the allocation to which the exception relates.|
-|`expenseId`| `string` |-| The unique identifier of the expense to which the exception relates.|
-|`parentExpenseId`| `string` |-| The unique identifier of the parent expense when the exception relates to an itemized expense.|
-
+| Name                  | Type      | Format         | Description                                                                                                                                                                                                                                                                                 |
+|-----------------------|-----------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `exceptionCode`       | `string`  | -              | **Required** The unique identifier of the exception type.                                                                                                                                                                                                                                   |
+| `exceptionVisibility` | `string`  | -              | **Required** The visibility of the exception. Possible values: 'ALL' - The exception is visible to the Traveler, Approver, and Processor, 'APPROVER_PROCESSOR' - The exception is visible only to the Approver and Processor, 'PROCESSOR' - The exception is visible only to the Processor. |
+| `isBlocking`          | `boolean` | `true`/`false` | **Required** Whether the exception will prevent the report from being submitted.                                                                                                                                                                                                            |
+| `message`             | `string`  | -              | Description of the exception, in the user's language.                                                                                                                                                                                                                                       |
+| `allocationId`        | `string`  | -              | The unique identifier of the allocation to which the exception relates.                                                                                                                                                                                                                     |
+| `expenseId`           | `string`  | -              | The unique identifier of the expense to which the exception relates.                                                                                                                                                                                                                        |
+| `parentExpenseId`     | `string`  | -              | The unique identifier of the parent expense when the exception relates to an itemized expense.                                                                                                                                                                                              |
 
 ### <a name="exception-request-schema"></a> Exception Request
 
-|Name|Type|Format| Description|
-|---|----|---|---|
-|`exceptionCode`| `string` |-| **Required** The code for the exception.|
-|`exceptionVisibility`| `string` |-| **Required** The visibility of the exception. Possible values: 'ALL' - The exception is visible to the Traveler, Approver, and Processor, 'APPROVER_PROCESSOR' - The exception is visible only to the Approver and Processor, 'PROCESSOR' - The exception is visible only to the Processor.|
-
+| Name                  | Type     | Format | Description                                                                                                                                                                                                                                                                                 |
+|-----------------------|----------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `exceptionCode`       | `string` | -      | **Required** The code for the exception.                                                                                                                                                                                                                                                    |
+| `exceptionVisibility` | `string` | -      | **Required** The visibility of the exception. Possible values: 'ALL' - The exception is visible to the Traveler, Approver, and Processor, 'APPROVER_PROCESSOR' - The exception is visible only to the Approver and Processor, 'PROCESSOR' - The exception is visible only to the Processor. |
 
 ### <a name="error-message-schema"></a>Error Message
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`customResponseData`|`object`|-|The custom parameters related to error.|
-|`errorId`|`string`|-|The unique identifier of the error associated with the response.|
-|`errorMessage`|`string`|-| **Required** The detailed error message.|
-|`httpStatus`|`string`|-| **Required** The HTTP response code and phrase for the response.|
-|`path`|`string`|-| **Required** The URI of the attempted request.|
-|`timestamp`|`string`|`date-time`| **Required** The time when the error was captured.|
-|`validationErrors`|[`ValidationError`](#validation-error-schema)|-|The validation error messages.|
+| Name                 | Type                                          | Format      | Description                                                      |
+|----------------------|-----------------------------------------------|-------------|------------------------------------------------------------------|
+| `customResponseData` | `object`                                      | -           | The custom parameters related to error.                          |
+| `errorId`            | `string`                                      | -           | The unique identifier of the error associated with the response. |
+| `errorMessage`       | `string`                                      | -           | **Required** The detailed error message.                         |
+| `httpStatus`         | `string`                                      | -           | **Required** The HTTP response code and phrase for the response. |
+| `path`               | `string`                                      | -           | **Required** The URI of the attempted request.                   |
+| `timestamp`          | `string`                                      | `date-time` | **Required** The time when the error was captured.               |
+| `validationErrors`   | [`ValidationError`](#validation-error-schema) | -           | The validation error messages.                                   |
 
 ### <a name="validation-errors-schema"></a>Validation Error
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|The ID of the validation error.|
-|`message`|`string`|-|The detailed message of the validation error.|
-|`source`|`string`|-|The type of validation which failed.|
+| Name      | Type     | Format | Description                                   |
+|-----------|----------|--------|-----------------------------------------------|
+| `id`      | `string` | -      | The ID of the validation error.               |
+| `message` | `string` | -      | The detailed message of the validation error. |
+| `source`  | `string` | -      | The type of validation which failed.          |

--- a/src/api-reference/expense/expense-report/v4.exceptions.markdown
+++ b/src/api-reference/expense/expense-report/v4.exceptions.markdown
@@ -56,12 +56,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-| Name              | Type      | Format        | Description                                                                                                                                        |
-|-------------------|-----------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `userID`          | `string`  | -             | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
-| `contextType`     | `string`  | -             | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
-| `reportId`        | `string`  | -             | **Required** The unique identifier of the report that is being read.                                                                               |
-| `excludeExpenses` | `boolean` | true or false | Include only exceptions for the report header. Default value: false                                                                                |
+| Name              | Type      | Format        | Description                                                                                                                                                   |
+|-------------------|-----------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`          | `string`  | -             | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.               |
+| `contextType`     | `string`  | -             | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `MANAGER`, `PROXY` |
+| `reportId`        | `string`  | -             | **Required** The unique identifier of the report that is being read.                                                                                          |
+| `excludeExpenses` | `boolean` | true or false | Include only exceptions for the report header. Default value: false                                                                                           |
 
 #### Headers
 
@@ -686,13 +686,13 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-| Name           | Type     | Format | Description                                                                                                                                        |
-|----------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `userID`       | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.    |
-| `contextType`  | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY` |
-| `reportId`     | `string` | -      | **Required** The unique identifier of the report that is being read.                                                                               |
-| `expenseId`    | `string` | -      | **Required** The unique identifier of the expense entry to which the exceptions belong.                                                            |
-| `allocationId` | `string` | -      | **Required** The unique identifier of the expense allocation to which the exceptions belong.                                                       |
+| Name           | Type     | Format | Description                                                                                                                                                  |
+|----------------|----------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`       | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4](/api-reference/profile/v4.identity.html) to retrieve the `userID`.              |
+| `contextType`  | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`,`MANAGER`, `PROXY` |
+| `reportId`     | `string` | -      | **Required** The unique identifier of the report that is being read.                                                                                         |
+| `expenseId`    | `string` | -      | **Required** The unique identifier of the expense entry to which the exceptions belong.                                                                      |
+| `allocationId` | `string` | -      | **Required** The unique identifier of the expense allocation to which the exceptions belong.                                                                 |
 
 #### Headers
 

--- a/src/api-reference/expense/expense-report/v4.expenses.markdown
+++ b/src/api-reference/expense/expense-report/v4.expenses.markdown
@@ -3,15 +3,19 @@ title: Expenses v4
 layout: reference
 
 ---
+
 # Expenses v4
 
-The Expenses API can be used to read the expenses that belong to a specific expense report and modify an expense on an existing expense report. This API can be used to change attributes like transaction date, transaction amount, location, etc.
+The Expenses API can be used to read the expenses that belong to a specific expense report and modify an expense on an
+existing expense report. This API can be used to change attributes like transaction date, transaction amount, location,
+etc.
 
 ## Prior Versions
 
 * Expense entry v1.1 (Deprecated) documentation is available [here](./v1dot1.expense-entry.html)
 * Expense Entry v3 documentation is available [here](./expense-entry.html)
-* Expense Itemizations v3 documentation is available [here](./api-reference/expense/expense-report/expense-itemization.html)
+* Expense Itemizations v3 documentation is
+  available [here](./api-reference/expense/expense-report/expense-itemization.html)
 
 ## <a name="limitations"></a>Limitations
 
@@ -26,22 +30,24 @@ Access to this documentation does not provide access to the API.
 
 Required Scopes:
 
-|Name|Description|Endpoint|
-|---|---|---|
-|`expense.report.read`|Get information about expense reports.|GET|
-|`expense.report.readwrite`|Read and write expense report headers.|PATCH|
-|`user.read`|Get User Information, necessary for `userID`.|GET|
+| Name                       | Description                                   | Endpoint |
+|----------------------------|-----------------------------------------------|----------|
+| `expense.report.read`      | Get information about expense reports.        | GET      |
+| `expense.report.readwrite` | Read and write expense report headers.        | PATCH    |
+| `user.read`                | Get User Information, necessary for `userID`. | GET      |
 
 Optional Scope:
 
-|Name|Description|Endpoint|
-|---|---|---|
-|`spend.listitem.read`|Read only access to spend list items `listItemId`.  |GET|
-|`spend.list.read`|Read only access to spend list and category details.| GET|
+| Name                  | Description                                          | Endpoint |
+|-----------------------|------------------------------------------------------|----------|
+| `spend.listitem.read` | Read only access to spend list items `listItemId`.   | GET      |
+| `spend.list.read`     | Read only access to spend list and category details. | GET      |
 
 ## Dependencies <a name="dependencies"></a>
 
-SAP Concur clients must purchase Concur Expense in order to use this API. This API requires the Identity v4 API which is currently only available to approved early access partners. Please contact your SAP Concur representative for more information.
+SAP Concur clients must purchase Concur Expense in order to use this API. This API requires the Identity v4 API which is
+currently only available to approved early access partners. Please contact your SAP Concur representative for more
+information.
 
 ## Access Token Usage <a name="access-token-usage"></a>
 
@@ -56,6 +62,7 @@ Retrieves the expenses that belong to a specific report ID.
 `expense.report.read` - Refer to [Scope Usage](#scope-usage) for full details.
 
 ### Request
+
 #### URI Template
 
 ```shell
@@ -64,11 +71,11 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported value: `TRAVELER` |
-|`reportId`|`string`|-|**Required** The unique identifier of the report that is being read.|
+| Name          | Type     | Format | Description                                                                                                                                         |
+|---------------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported value: `TRAVELER`            |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report that is being read.                                                                                |
 
 #### Headers
 
@@ -78,7 +85,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
 
 ### Response
 
@@ -294,7 +302,6 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 ]
 ```
 
-
 ## Retrieve an Expense by ID <a name="retrieve-expense-entry"></a>
 
 Retrieves the details of the specific expense entry on a report.
@@ -304,6 +311,7 @@ Retrieves the details of the specific expense entry on a report.
 `expense.report.read` - Refer to [Scope Usage](#scope-usage) for full details.
 
 ### Request
+
 #### URI Template
 
 ```shell
@@ -312,12 +320,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported value: `TRAVELER`, `PROXY`|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry that is being read.|
+| Name          | Type     | Format | Description                                                                                                                                                  |
+|---------------|----------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`.          |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported value: `TRAVELER`, `MANAGER`, `PROXY` |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs.                                                                        |
+| `expenseId`   | `string` | -      | **Required** The unique identifier of the expense entry that is being read.                                                                                  |
 
 #### Headers
 
@@ -327,7 +335,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
 
 ### Response
 
@@ -507,6 +516,7 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
     "lastModifiedDate": null
 }
 ```
+
 ## Retrieve Itemizations on a Specific Expense ID <a name="specific-expense-itemizations"></a>
 
 Retrieves the itemizations that belong to a specific expense ID.
@@ -516,6 +526,7 @@ Retrieves the itemizations that belong to a specific expense ID.
 `expense.report.read` - Refer to [Scope Usage](#scope-usage) for full details.
 
 ### Request
+
 #### URI Template
 
 ```shell
@@ -524,13 +535,12 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-| Name|Type|Format|Description|
-|---|---|---|---|
-| `userID` |`string`|-| **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
-| `contextType` |`string`|-| **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported value: `TRAVELER`            |
-| `reportId`    |`string`|-| **Required** The unique identifier of the report that is being read. |
-| `expenseId`   |`string`|-| **Required** The unique identifier of the expense that is being read.|
-
+| Name          | Type     | Format | Description                                                                                                                                         |
+|---------------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported value: `TRAVELER`            |
+| `reportId`    | `string` | -      | **Required** The unique identifier of the report that is being read.                                                                                |
+| `expenseId`   | `string` | -      | **Required** The unique identifier of the expense that is being read.                                                                               |
 
 ### Response
 
@@ -728,13 +738,15 @@ curl --location --request GET 'https://us.api.concursolutions.com/expensereports
 
 ## Update a Specific Expense Entry in a Submitted Report <a name="update-expense-entry-in-a-submitted-report"></a>
 
-Updates the specified expense on an unsubmitted or submitted report and is restricted to modify 'Business Purpose', 'Custom/Org unit', 'Expense Rejected' and 'Paper Receipt Received' fields only.
+Updates the specified expense on an unsubmitted or submitted report and is restricted to modify 'Business Purpose', '
+Custom/Org unit', 'Expense Rejected' and 'Paper Receipt Received' fields only.
 
 ### Scopes
 
 `expense.report.readwrite` - Refer to [Scope Usage](#scope-usage) for full details.
 
 ### Request
+
 #### URI Template
 
 ```shell
@@ -743,10 +755,10 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
-|`expenseId`|`string`|-|**Required** The unique identifier of the expense entry that is being read.|
+| Name        | Type     | Format | Description                                                                           |
+|-------------|----------|--------|---------------------------------------------------------------------------------------|
+| `reportId`  | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs. |
+| `expenseId` | `string` | -      | **Required** The unique identifier of the expense entry that is being read.           |
 
 #### Headers
 
@@ -756,7 +768,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}/expenses/{expenseId
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
 
 #### REST Design Specification
 
@@ -785,22 +798,21 @@ PATCH operations in Expense Reports v4 conform to the JSON Merge Patch specifica
 
 ### <a name="update-report-expense-compact-schema"></a>Update Report Expense Compact Schema
 
-|Name|Type|Format| Description                                                                                                                                                                                                 |
-|---|---|---|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|`businessPurpose`|`string`|-| The text input for the business purpose by the user. Maximum length: 64 characters.                                                                                                                         |
-|`customData`|[`CustomData`](#custom-data-schema)|-| The details from the `customData` fields. These fields may not have data, depending on the configuration.                                                                                                   |
-|`expenseSource`|`string`|-| **Required** The source of the expense. Supported values: `EA` - Expense Assistant, `MOB` - Mobile, `OTHER` - Unknown, `SE` - Smart Expense, `TA` - Travel Allowance, `TR` - Travel Request, `UI` - Web UI. |
-|`isExpenseRejected`|`boolean`|`true`/`false`| Whether the approver or processor has rejected this expense in the report. If this is true then this expense will be sent back to the report submitted in an addendum (split) report.                       |
-|`isPaperReceiptReceived`|`boolean`|`true`/`false`| Whether paper receipts have been received for the expense.             |
-
+| Name                     | Type                                | Format         | Description                                                                                                                                                                                                 |
+|--------------------------|-------------------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `businessPurpose`        | `string`                            | -              | The text input for the business purpose by the user. Maximum length: 64 characters.                                                                                                                         |
+| `customData`             | [`CustomData`](#custom-data-schema) | -              | The details from the `customData` fields. These fields may not have data, depending on the configuration.                                                                                                   |
+| `expenseSource`          | `string`                            | -              | **Required** The source of the expense. Supported values: `EA` - Expense Assistant, `MOB` - Mobile, `OTHER` - Unknown, `SE` - Smart Expense, `TA` - Travel Allowance, `TR` - Travel Request, `UI` - Web UI. |
+| `isExpenseRejected`      | `boolean`                           | `true`/`false` | Whether the approver or processor has rejected this expense in the report. If this is true then this expense will be sent back to the report submitted in an addendum (split) report.                       |
+| `isPaperReceiptReceived` | `boolean`                           | `true`/`false` | Whether paper receipts have been received for the expense.                                                                                                                                                  |
 
 #### <a name="report-expense-custom-data-schema"></a>CustomData
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|**Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`|
-|`isValid`|`boolean`|`true`/`false`|Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true`|
-|`value`|`string`|-|The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters|
+| Name      | Type      | Format         | Description                                                                                                                                                                                          |
+|-----------|-----------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`      | `string`  | -              | **Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`                                                                                                              |
+| `isValid` | `boolean` | `true`/`false` | Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true` |
+| `value`   | `string`  | -              | The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters                      |
 
 ### Example
 
@@ -836,459 +848,459 @@ curl --location --request PATCH 'https://us.api.concursolutions.com/expenserepor
 
 ### <a name="report-expense-summary-schema"></a>ReportExpenseSummary
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`allocationSetId`|`string`|-|The identifier of the allocation set associated with the expense. Allocations which belong to the same set were created at the same time.|
-|`allocationState`|`string`|-|**Required** Allocation state for the expense. Supported values: `FULLY_ALLOCATED`, `NOT_ALLOCATED`, `PARTIALLY_ALLOCATED`|
-|`approvedAmount`|[`Amount`](#amount-schema)|-|The approved amount of the expense, in the report currency.|
-|`approverAdjustedAmount`|[`Amount`](#amount-schema)|-|The total amount adjusted for the expense by the approver|
-|`attendeeCount`|`integer`|`int32`|The total number of attendees associated with the expense.|
-|`businessPurpose`|`string`|-|The text input for the business purpose by the user.|
-|`claimedAmount`|[`Amount`](#amount-schema)|-|The total non-personal amount claimed for reimbursement for the expense.|
-|`ereceiptImageId`|`string`|-|The unique identifier of the eReceipt image associated with the expense.|
-|`exchangeRate`|[`ExchangeRate`](#exchange-rate-schema)|-|**Required** Exchange rate data for the expense.|
-|`expenseId`|`string`|-|**Required** The unique identifier for the expense.|
-|`expenseSourceIdentifiers`|[`ExpenseSourceIdentifiers`](#expense-source-identifiers-schema)|-|The list of expense sources associated with the expense|
-|`expenseType`|[`ExpenseType`](#expense-type-schema)|-|**Required** The expense type information for the expense.|
-|`fuelTypeListItem`|[`CustomData`](#custom-data-schema)|-| The unique id of Fuel Type.|
-|`hasBlockingExceptions`|`boolean`|-|**Required** Whether the expense has any exceptions that block it from being submitted.|
-|`hasExceptions`|`boolean`|`true`/`false`|**Required** Whether the expense has any exceptions.|
-|`hasMissingReceiptDeclaration`|`boolean`|`true`/`false`|**Required** Whether the expense has an affidavit declaration for missing receipt.|
-|`imageCertificationStatus`|`string`|-|The final status of the receipt image associated with the expense.|
-|`isAutoCreated`|`boolean`|`true`/`false`|**Required** Whether the expense is auto-created.|
-|`isImageRequired`|`boolean`|`true`/`false`|**Required** Whether the image is required for the expense.|
-|`isPaperReceiptRequired`|`boolean`|`true`/`false`|**Required** Whether the paper receipt is required for the expense to be submitted.|
-|`isPersonalExpense`|`boolean`|`true`/`false`|**Required** Whether the expense is marked as personal (non-reimbursable) by the user.|
-|`jptRouteId`|`string`|-|The unique route ID to identify a Japan rail route.|
-|`links`|[`Link`](#link-schema)|-|Resource links related to this call.|
-|`location`|[`Location`](#location-schema)|-|The location information of the expense.|
-|`paymentType`|[`PaymentType`](#payment-type-schema)|-|**Required** The payment type information for the expense.|
-|`postedAmount`|[`Amount`](#amount-schema)|-|**Required** The amount of the expense, in the report currency.|
-|`receiptImageId`|`string`|-|The unique identifier of the image associated with the expense.|
-|`ticketNumber`|`string`|-|The ticket number associated with the travel.|
-|`transactionAmount`|[`Amount`](#amount-schema)|-|**Required** The amount of the expense, in the transaction currency paid to the vendor.|
-|`transactionDate`|`string`|`YYYY-MM-DD`|The transaction date.|
-|`travelAllowance`|[`TravelAllowance`](#travel-allowance-schema)|-|The travel allowance data associated with the expense.|
-|`vendor`|[`Vendor`](#vendor-schema)|-|The vendor information for the expense.|
+| Name                           | Type                                                             | Format         | Description                                                                                                                               |
+|--------------------------------|------------------------------------------------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `allocationSetId`              | `string`                                                         | -              | The identifier of the allocation set associated with the expense. Allocations which belong to the same set were created at the same time. |
+| `allocationState`              | `string`                                                         | -              | **Required** Allocation state for the expense. Supported values: `FULLY_ALLOCATED`, `NOT_ALLOCATED`, `PARTIALLY_ALLOCATED`                |
+| `approvedAmount`               | [`Amount`](#amount-schema)                                       | -              | The approved amount of the expense, in the report currency.                                                                               |
+| `approverAdjustedAmount`       | [`Amount`](#amount-schema)                                       | -              | The total amount adjusted for the expense by the approver                                                                                 |
+| `attendeeCount`                | `integer`                                                        | `int32`        | The total number of attendees associated with the expense.                                                                                |
+| `businessPurpose`              | `string`                                                         | -              | The text input for the business purpose by the user.                                                                                      |
+| `claimedAmount`                | [`Amount`](#amount-schema)                                       | -              | The total non-personal amount claimed for reimbursement for the expense.                                                                  |
+| `ereceiptImageId`              | `string`                                                         | -              | The unique identifier of the eReceipt image associated with the expense.                                                                  |
+| `exchangeRate`                 | [`ExchangeRate`](#exchange-rate-schema)                          | -              | **Required** Exchange rate data for the expense.                                                                                          |
+| `expenseId`                    | `string`                                                         | -              | **Required** The unique identifier for the expense.                                                                                       |
+| `expenseSourceIdentifiers`     | [`ExpenseSourceIdentifiers`](#expense-source-identifiers-schema) | -              | The list of expense sources associated with the expense                                                                                   |
+| `expenseType`                  | [`ExpenseType`](#expense-type-schema)                            | -              | **Required** The expense type information for the expense.                                                                                |
+| `fuelTypeListItem`             | [`CustomData`](#custom-data-schema)                              | -              | The unique id of Fuel Type.                                                                                                               |
+| `hasBlockingExceptions`        | `boolean`                                                        | -              | **Required** Whether the expense has any exceptions that block it from being submitted.                                                   |
+| `hasExceptions`                | `boolean`                                                        | `true`/`false` | **Required** Whether the expense has any exceptions.                                                                                      |
+| `hasMissingReceiptDeclaration` | `boolean`                                                        | `true`/`false` | **Required** Whether the expense has an affidavit declaration for missing receipt.                                                        |
+| `imageCertificationStatus`     | `string`                                                         | -              | The final status of the receipt image associated with the expense.                                                                        |
+| `isAutoCreated`                | `boolean`                                                        | `true`/`false` | **Required** Whether the expense is auto-created.                                                                                         |
+| `isImageRequired`              | `boolean`                                                        | `true`/`false` | **Required** Whether the image is required for the expense.                                                                               |
+| `isPaperReceiptRequired`       | `boolean`                                                        | `true`/`false` | **Required** Whether the paper receipt is required for the expense to be submitted.                                                       |
+| `isPersonalExpense`            | `boolean`                                                        | `true`/`false` | **Required** Whether the expense is marked as personal (non-reimbursable) by the user.                                                    |
+| `jptRouteId`                   | `string`                                                         | -              | The unique route ID to identify a Japan rail route.                                                                                       |
+| `links`                        | [`Link`](#link-schema)                                           | -              | Resource links related to this call.                                                                                                      |
+| `location`                     | [`Location`](#location-schema)                                   | -              | The location information of the expense.                                                                                                  |
+| `paymentType`                  | [`PaymentType`](#payment-type-schema)                            | -              | **Required** The payment type information for the expense.                                                                                |
+| `postedAmount`                 | [`Amount`](#amount-schema)                                       | -              | **Required** The amount of the expense, in the report currency.                                                                           |
+| `receiptImageId`               | `string`                                                         | -              | The unique identifier of the image associated with the expense.                                                                           |
+| `ticketNumber`                 | `string`                                                         | -              | The ticket number associated with the travel.                                                                                             |
+| `transactionAmount`            | [`Amount`](#amount-schema)                                       | -              | **Required** The amount of the expense, in the transaction currency paid to the vendor.                                                   |
+| `transactionDate`              | `string`                                                         | `YYYY-MM-DD`   | The transaction date.                                                                                                                     |
+| `travelAllowance`              | [`TravelAllowance`](#travel-allowance-schema)                    | -              | The travel allowance data associated with the expense.                                                                                    |
+| `vendor`                       | [`Vendor`](#vendor-schema)                                       | -              | The vendor information for the expense.                                                                                                   |
 
 ### <a name="report-expense-detail-schema"></a>ReportExpenseDetail
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`allocationSetId`|`string`|-|The identifier of the allocation set associated with the expense. Allocations which belong to the same set are created at the same time.|
-|`allocationState`|`string`|-|**Required** Allocation state for the expense. Supported values: `FULLY_ALLOCATED`, `NOT_ALLOCATED`, `PARTIALLY_ALLOCATED`|
-|`approvedAmount`|[`Amount`](#amount-schema)|-|The approved amount of the expense, in the report currency.|
-|`approverAdjustedAmount`|[`Amount`](#amount-schema)|-|The total amount adjusted for the expense by the approver.|
-|`attendeeCount`|`integer`|`int32`|The total number of attendees associated with the expense.|
-|`authorizationRequestExpenseId`|`string`|-|The authorization request expense ID associated with the expense.|
-|`budgetAccrualDate`|`string`|`YYYY-MM-DD`|The budget accrual date of the expense.|
-|`businessPurpose`|`string`|-|The text input for the business purpose by the user.|
-|`claimedAmount`|[`Amount`](#amount-schema)|-|The total non-personal amount claimed for reimbursement for the expense|
-|`customData`|[`CustomData`](#custom-data-schema)|-|The details from the `customData` fields. These fields may not have data, depending on the configuration.|
-|`ereceiptImageId`|`string`|-|The unique identifier of the eReceipt image associated with the expense.|
-|`exchangeRate`|[`ExchangeRate`](#exchange-rate-schema)|-|**Required** Exchange rate data for the expense.|
-|`expenseId`|`string`|-|**Required** The unique identifier for the expense|
-|`expenseSourceIdentifiers`|[`ExpenseSourceIdentifiers`](#expense-source-identifiers-schema)|-|The list of expense sources associated with the expense.|
-|`expenseTaxSummary`|[`ExpenseTaxSummary`](#expense-tax-sumamry-schema)|-|Tax information for the expense.|
-|`expenseType`|[`ExpenseType`](#expense-type-schema)|-|**Required** The expense type information for the expense.|
-|`fuelTypeListItem`|[`CustomData`](#custom-data-schema)|-| The unique id of Fuel Type.|
-|`hasBlockingExceptions`|`boolean`|`true`/`false`|**Required** Whether the expense has any exceptions that blocks it from being submitted.|
-|`hasExceptions`|`boolean`|`true`/`false`|**Required** Whether the expense has any exceptions.|
-|`hasMissingReceiptDeclaration`|`boolean`|`true`/`false`|Whether the expense has an affidavit declaration for missing receipt.|
-|`imageCertificationStatus`|`string`|-|The final status of the receipt image associated with the expense. Supported values: `ACCEPTED`, `PROCESSED`, `PROCESSING`, `PDF`, `FAILED`, `NO_PROCESSING_REQUIRED`|
-|`isAutoCreated`|`boolean`|`true`/`false`|**Required** Whether the expense is auto created.|
-|`isExcludedFromCashAdvanceByUser`|`boolean`|`true`/`false`|**Required** Whether the user has excluded the expense from cash advance.|
-|`isExpenseBillable`|`boolean`|`true`/`false`|**Required** Whether the expense is billable.|
-|`isExpenseRejected`|`boolean`|`true`/`false`|**Required** Whether the approver or processor has rejected this expense in the report. If `true`, then this expense will be sent back to the report submitted in an addendum (split) report.|
-|`isImageRequired`|`boolean`|`true`/`false`|**Required** Whether the image is required for the expense.|
-|`isPaperReceiptReceived`|`boolean`|`true`/`false`|**Required** Whether the paper receipt was received for the expense.|
-|`isPaperReceiptRequired`|`boolean`|`true`/`false`|**Required** Whether the paper receipt is required for the expense to be submitted.|
-|`isPersonalExpense`|`boolean`|`true`/`false`|**Required** Whether the expense is marked as personal (non-reimbursable) by the user.|
-|`jptRouteId`|`string`|-|The unique route ID to identify a Japan rail route.|
-|`links`|[`Link`](#link-schema)|-|Resource links related to this call.|
-|`location`|[`Location`](#location-schema)|-|The location information of the expense.|
-|`merchantTaxId`|`string`|-|Merchant tax ID for the expense.|
-|`mileage`|[`Mileage`](#mileage-schema)|-|The mileage data associated with the expense.|
-|`parentExpenseId`|`string`|-|Expense ID of the parent expense.|
-|`paymentType`|[`PaymentType`](#payment-type-schema)|-|**Required** The payment type information for the expense.|
-|`postedAmount`|[`Amount`](#amount-schema)|-|**Required** The amount of the expense, in the report currency.|
-|`receiptImageId`|`string`|-|The unique identifier of the image associated with the expense.|
-|`receiptType`|[`ReceiptType`](#receipt-type-schema)|-|Receipt type for the expense.|
-|`taxRateLocation`|`string`|-|**Required** Transaction location relative to the employee's home location as defined by their user profile. Supported values: `FOREIGN` - The expense transaction took place in foreign currency, `HOME` - The expense transaction took place in the reimbursement currency, `OUT_OF_PROVINCE` - The expense transaction took place outside the state jurisdiction. Default: `HOME`|
-|`transactionAmount`|[`Amount`](#amount-schema)|-|**Required** The amount of the expense, in the transaction currency paid to the vendor.|
-|`transactionDate`|`string`|`YYYY-MM-DD`|The transaction date of the expense.|
-|`travel`|[`Travel`](#travel-schema)|-|The travel data associated with the expense.|
-|`travelAllowance`|[`TravelAllowance`](#travel-allowance-schema)|-|The travel allowance data associated with the expense.|
-|`vendor`|[`Vendor`](#vendor-schema)|-|The vendor information for the expense.|
-|`lastModifiedDate`|`string`|`YYYY-MM-DDTHH:mm:ssZ`|The UTC datetime of when the expense was last modified (ISO-8601)(https://www.iso.org/iso-8601-date-and-time-format.html).|
+| Name                              | Type                                                             | Format                 | Description                                                                                                                                                                                                                                                                                                                                                                          |
+|-----------------------------------|------------------------------------------------------------------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `allocationSetId`                 | `string`                                                         | -                      | The identifier of the allocation set associated with the expense. Allocations which belong to the same set are created at the same time.                                                                                                                                                                                                                                             |
+| `allocationState`                 | `string`                                                         | -                      | **Required** Allocation state for the expense. Supported values: `FULLY_ALLOCATED`, `NOT_ALLOCATED`, `PARTIALLY_ALLOCATED`                                                                                                                                                                                                                                                           |
+| `approvedAmount`                  | [`Amount`](#amount-schema)                                       | -                      | The approved amount of the expense, in the report currency.                                                                                                                                                                                                                                                                                                                          |
+| `approverAdjustedAmount`          | [`Amount`](#amount-schema)                                       | -                      | The total amount adjusted for the expense by the approver.                                                                                                                                                                                                                                                                                                                           |
+| `attendeeCount`                   | `integer`                                                        | `int32`                | The total number of attendees associated with the expense.                                                                                                                                                                                                                                                                                                                           |
+| `authorizationRequestExpenseId`   | `string`                                                         | -                      | The authorization request expense ID associated with the expense.                                                                                                                                                                                                                                                                                                                    |
+| `budgetAccrualDate`               | `string`                                                         | `YYYY-MM-DD`           | The budget accrual date of the expense.                                                                                                                                                                                                                                                                                                                                              |
+| `businessPurpose`                 | `string`                                                         | -                      | The text input for the business purpose by the user.                                                                                                                                                                                                                                                                                                                                 |
+| `claimedAmount`                   | [`Amount`](#amount-schema)                                       | -                      | The total non-personal amount claimed for reimbursement for the expense                                                                                                                                                                                                                                                                                                              |
+| `customData`                      | [`CustomData`](#custom-data-schema)                              | -                      | The details from the `customData` fields. These fields may not have data, depending on the configuration.                                                                                                                                                                                                                                                                            |
+| `ereceiptImageId`                 | `string`                                                         | -                      | The unique identifier of the eReceipt image associated with the expense.                                                                                                                                                                                                                                                                                                             |
+| `exchangeRate`                    | [`ExchangeRate`](#exchange-rate-schema)                          | -                      | **Required** Exchange rate data for the expense.                                                                                                                                                                                                                                                                                                                                     |
+| `expenseId`                       | `string`                                                         | -                      | **Required** The unique identifier for the expense                                                                                                                                                                                                                                                                                                                                   |
+| `expenseSourceIdentifiers`        | [`ExpenseSourceIdentifiers`](#expense-source-identifiers-schema) | -                      | The list of expense sources associated with the expense.                                                                                                                                                                                                                                                                                                                             |
+| `expenseTaxSummary`               | [`ExpenseTaxSummary`](#expense-tax-sumamry-schema)               | -                      | Tax information for the expense.                                                                                                                                                                                                                                                                                                                                                     |
+| `expenseType`                     | [`ExpenseType`](#expense-type-schema)                            | -                      | **Required** The expense type information for the expense.                                                                                                                                                                                                                                                                                                                           |
+| `fuelTypeListItem`                | [`CustomData`](#custom-data-schema)                              | -                      | The unique id of Fuel Type.                                                                                                                                                                                                                                                                                                                                                          |
+| `hasBlockingExceptions`           | `boolean`                                                        | `true`/`false`         | **Required** Whether the expense has any exceptions that blocks it from being submitted.                                                                                                                                                                                                                                                                                             |
+| `hasExceptions`                   | `boolean`                                                        | `true`/`false`         | **Required** Whether the expense has any exceptions.                                                                                                                                                                                                                                                                                                                                 |
+| `hasMissingReceiptDeclaration`    | `boolean`                                                        | `true`/`false`         | Whether the expense has an affidavit declaration for missing receipt.                                                                                                                                                                                                                                                                                                                |
+| `imageCertificationStatus`        | `string`                                                         | -                      | The final status of the receipt image associated with the expense. Supported values: `ACCEPTED`, `PROCESSED`, `PROCESSING`, `PDF`, `FAILED`, `NO_PROCESSING_REQUIRED`                                                                                                                                                                                                                |
+| `isAutoCreated`                   | `boolean`                                                        | `true`/`false`         | **Required** Whether the expense is auto created.                                                                                                                                                                                                                                                                                                                                    |
+| `isExcludedFromCashAdvanceByUser` | `boolean`                                                        | `true`/`false`         | **Required** Whether the user has excluded the expense from cash advance.                                                                                                                                                                                                                                                                                                            |
+| `isExpenseBillable`               | `boolean`                                                        | `true`/`false`         | **Required** Whether the expense is billable.                                                                                                                                                                                                                                                                                                                                        |
+| `isExpenseRejected`               | `boolean`                                                        | `true`/`false`         | **Required** Whether the approver or processor has rejected this expense in the report. If `true`, then this expense will be sent back to the report submitted in an addendum (split) report.                                                                                                                                                                                        |
+| `isImageRequired`                 | `boolean`                                                        | `true`/`false`         | **Required** Whether the image is required for the expense.                                                                                                                                                                                                                                                                                                                          |
+| `isPaperReceiptReceived`          | `boolean`                                                        | `true`/`false`         | **Required** Whether the paper receipt was received for the expense.                                                                                                                                                                                                                                                                                                                 |
+| `isPaperReceiptRequired`          | `boolean`                                                        | `true`/`false`         | **Required** Whether the paper receipt is required for the expense to be submitted.                                                                                                                                                                                                                                                                                                  |
+| `isPersonalExpense`               | `boolean`                                                        | `true`/`false`         | **Required** Whether the expense is marked as personal (non-reimbursable) by the user.                                                                                                                                                                                                                                                                                               |
+| `jptRouteId`                      | `string`                                                         | -                      | The unique route ID to identify a Japan rail route.                                                                                                                                                                                                                                                                                                                                  |
+| `links`                           | [`Link`](#link-schema)                                           | -                      | Resource links related to this call.                                                                                                                                                                                                                                                                                                                                                 |
+| `location`                        | [`Location`](#location-schema)                                   | -                      | The location information of the expense.                                                                                                                                                                                                                                                                                                                                             |
+| `merchantTaxId`                   | `string`                                                         | -                      | Merchant tax ID for the expense.                                                                                                                                                                                                                                                                                                                                                     |
+| `mileage`                         | [`Mileage`](#mileage-schema)                                     | -                      | The mileage data associated with the expense.                                                                                                                                                                                                                                                                                                                                        |
+| `parentExpenseId`                 | `string`                                                         | -                      | Expense ID of the parent expense.                                                                                                                                                                                                                                                                                                                                                    |
+| `paymentType`                     | [`PaymentType`](#payment-type-schema)                            | -                      | **Required** The payment type information for the expense.                                                                                                                                                                                                                                                                                                                           |
+| `postedAmount`                    | [`Amount`](#amount-schema)                                       | -                      | **Required** The amount of the expense, in the report currency.                                                                                                                                                                                                                                                                                                                      |
+| `receiptImageId`                  | `string`                                                         | -                      | The unique identifier of the image associated with the expense.                                                                                                                                                                                                                                                                                                                      |
+| `receiptType`                     | [`ReceiptType`](#receipt-type-schema)                            | -                      | Receipt type for the expense.                                                                                                                                                                                                                                                                                                                                                        |
+| `taxRateLocation`                 | `string`                                                         | -                      | **Required** Transaction location relative to the employee's home location as defined by their user profile. Supported values: `FOREIGN` - The expense transaction took place in foreign currency, `HOME` - The expense transaction took place in the reimbursement currency, `OUT_OF_PROVINCE` - The expense transaction took place outside the state jurisdiction. Default: `HOME` |
+| `transactionAmount`               | [`Amount`](#amount-schema)                                       | -                      | **Required** The amount of the expense, in the transaction currency paid to the vendor.                                                                                                                                                                                                                                                                                              |
+| `transactionDate`                 | `string`                                                         | `YYYY-MM-DD`           | The transaction date of the expense.                                                                                                                                                                                                                                                                                                                                                 |
+| `travel`                          | [`Travel`](#travel-schema)                                       | -                      | The travel data associated with the expense.                                                                                                                                                                                                                                                                                                                                         |
+| `travelAllowance`                 | [`TravelAllowance`](#travel-allowance-schema)                    | -                      | The travel allowance data associated with the expense.                                                                                                                                                                                                                                                                                                                               |
+| `vendor`                          | [`Vendor`](#vendor-schema)                                       | -                      | The vendor information for the expense.                                                                                                                                                                                                                                                                                                                                              |
+| `lastModifiedDate`                | `string`                                                         | `YYYY-MM-DDTHH:mm:ssZ` | The UTC datetime of when the expense was last modified (ISO-8601)(https://www.iso.org/iso-8601-date-and-time-format.html).                                                                                                                                                                                                                                                           |
 
 ### <a name="custom-data-schema"></a>CustomData
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|**Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`|
-|`isValid`|`boolean`|`true`/`false`|Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true`|
-|`value`|`string`|-|The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters|
+| Name      | Type      | Format         | Description                                                                                                                                                                                          |
+|-----------|-----------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`      | `string`  | -              | **Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`                                                                                                              |
+| `isValid` | `boolean` | `true`/`false` | Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true` |
+| `value`   | `string`  | -              | The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters                      |
 
 ### <a name="amount-schema"></a>Amount
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`currencyCode`|`string`|-|**Required** The 3-letter ISO 4217 currency code for the expense report currency, based on the user's assigned reimbursement currency when the report was created. Examples: `USD` - US dollars; `BRL` - Brazilian real; `CAD` - Canadian dollar; `CHF` - Swiss franc; `EUR` - Euro; `GBO` - Pound sterling; `HKD` - Hong Kong dollar; `INR` - Indian rupee; `MXN` - Mexican peso; `NOK` - Norwegian krone; `SEK` - Swedish krona|
-|`value`|`number`|`double`|**Required** The amount in the defined currency.|
+| Name           | Type     | Format   | Description                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|----------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `currencyCode` | `string` | -        | **Required** The 3-letter ISO 4217 currency code for the expense report currency, based on the user's assigned reimbursement currency when the report was created. Examples: `USD` - US dollars; `BRL` - Brazilian real; `CAD` - Canadian dollar; `CHF` - Swiss franc; `EUR` - Euro; `GBO` - Pound sterling; `HKD` - Hong Kong dollar; `INR` - Indian rupee; `MXN` - Mexican peso; `NOK` - Norwegian krone; `SEK` - Swedish krona |
+| `value`        | `number` | `double` | **Required** The amount in the defined currency.                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ### <a name="expense-source-identifiers-schema"></a>ExpenseSourceIdentifiers
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`creditCardTransactionId`|`string`| - |The unique identifier of the credit card transaction (indexed `transactionId`) associated with the expense.|
-|`ereceiptId`| `string` | - | - |
-|`eReceiptURL`|`string` | -  |The URL to get details of the associated eReceipt.|
-|`expenseCaptureImageId` |`string` | - |The unique identifier of the expense capture image associated with the expense.|
-|`jptRouteId`|`string` | - |The unique identifier to identify a Japan rail route.|
-|`personalCardTransactionId` |`string` | - |The unique identifier of the personal card transaction associated with the expense.|
-|`quickExpenseId`|`string` | - |The unique identifier of the mobile expense associated with the expense. |
-|`receiptImageId`|`string` | -  |The unique identifier of the image associated with the expense. |
-|`receipts`|`array` |[ReportReceiptMapping](#report-receipt-mapping) |Details for the associated receipts from Receipt Service v5.|
-|`segmentId`|`integer` |`int64`|The unique identifier of the segment associated with the expense.|
-|`segmentTypeId`|`string` | - |Segment type ID associated with the trip. Supported values: `AIRFR` - Air Ticket, `AIRSU` - Air Subscription, `CARRT` - Car Rental, `DININ` - Dining, `EVENT` - Event, `HOTEL` - Hotel Reservation, `INSUR` - Insurance, `LIMOF` - Limousine Reservation, `MISC` - Miscellaneous, `PARKG` - Parking Fee, `RAILF` - Train Ticket, `RAISU` - Train Subscription, `TAXIF` - Taxi Fare, `VISA` - Visa |
-|`tripId`|`integer` |`int64`|The unique identifier of the trip ID associated with the expense. |
+| Name                        | Type      | Format                                          | Description                                                                                                                                                                                                                                                                                                                                                                                       |
+|-----------------------------|-----------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `creditCardTransactionId`   | `string`  | -                                               | The unique identifier of the credit card transaction (indexed `transactionId`) associated with the expense.                                                                                                                                                                                                                                                                                       |
+| `ereceiptId`                | `string`  | -                                               | -                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `eReceiptURL`               | `string`  | -                                               | The URL to get details of the associated eReceipt.                                                                                                                                                                                                                                                                                                                                                |
+| `expenseCaptureImageId`     | `string`  | -                                               | The unique identifier of the expense capture image associated with the expense.                                                                                                                                                                                                                                                                                                                   |
+| `jptRouteId`                | `string`  | -                                               | The unique identifier to identify a Japan rail route.                                                                                                                                                                                                                                                                                                                                             |
+| `personalCardTransactionId` | `string`  | -                                               | The unique identifier of the personal card transaction associated with the expense.                                                                                                                                                                                                                                                                                                               |
+| `quickExpenseId`            | `string`  | -                                               | The unique identifier of the mobile expense associated with the expense.                                                                                                                                                                                                                                                                                                                          |
+| `receiptImageId`            | `string`  | -                                               | The unique identifier of the image associated with the expense.                                                                                                                                                                                                                                                                                                                                   |
+| `receipts`                  | `array`   | [ReportReceiptMapping](#report-receipt-mapping) | Details for the associated receipts from Receipt Service v5.                                                                                                                                                                                                                                                                                                                                      |
+| `segmentId`                 | `integer` | `int64`                                         | The unique identifier of the segment associated with the expense.                                                                                                                                                                                                                                                                                                                                 |
+| `segmentTypeId`             | `string`  | -                                               | Segment type ID associated with the trip. Supported values: `AIRFR` - Air Ticket, `AIRSU` - Air Subscription, `CARRT` - Car Rental, `DININ` - Dining, `EVENT` - Event, `HOTEL` - Hotel Reservation, `INSUR` - Insurance, `LIMOF` - Limousine Reservation, `MISC` - Miscellaneous, `PARKG` - Parking Fee, `RAILF` - Train Ticket, `RAISU` - Train Subscription, `TAXIF` - Taxi Fare, `VISA` - Visa |
+| `tripId`                    | `integer` | `int64`                                         | The unique identifier of the trip ID associated with the expense.                                                                                                                                                                                                                                                                                                                                 |
 
 ### <a name="report-receipt-mapping"></a>Report Receipt Mapping
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`receiptId` |`string` | UUID  |**Required** The unique identifier of the Receipt with the expense.|
-|`imageId`  |`string` | -   |**Required** The unique identifier of the Receipt image associated with the expense.|
-|`feature` |`string` | -  |**Required** Receipt feature of the Receipt with the expense. Supported values: 'expenseIt'|
-|`version`|`string` | -  |Receipt version of the Receipt with the expense. Default value: 5|
+| Name        | Type     | Format | Description                                                                                 |
+|-------------|----------|--------|---------------------------------------------------------------------------------------------|
+| `receiptId` | `string` | UUID   | **Required** The unique identifier of the Receipt with the expense.                         |
+| `imageId`   | `string` | -      | **Required** The unique identifier of the Receipt image associated with the expense.        |
+| `feature`   | `string` | -      | **Required** Receipt feature of the Receipt with the expense. Supported values: 'expenseIt' |
+| `version`   | `string` | -      | Receipt version of the Receipt with the expense. Default value: 5                           |
 
 ### <a name="exchange-rate-schema"></a>ExchangeRate
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`operation`|`string`|-|**Required** Exchange rate operation. Supported values: `MULTIPLY` or `DIVIDE`|
-|`value`|`number`|`double`|**Required** Exchange rate value.|
+| Name        | Type     | Format   | Description                                                                    |
+|-------------|----------|----------|--------------------------------------------------------------------------------|
+| `operation` | `string` | -        | **Required** Exchange rate operation. Supported values: `MULTIPLY` or `DIVIDE` |
+| `value`     | `number` | `double` | **Required** Exchange rate value.                                              |
 
 ### <a name="expense-tax-summary-schema"></a>ExpenseTaxSummary
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`netAdjustedTaxAmount`|[`Amount`](#amount-schema)|-|Net adjusted tax amount.|
-|`netReclaimAdjustedAmount`|[`Amount`](#amount-schema)|-|Net reclaim adjusted amount.|
-|`netReclaimAmount`|[`Amount`](#amount-schema)|-|Net reclaim amount.|
-|`netTaxAmount`|[`Amount`](#amount-schema)|-|Net tax amount.|
-|`totalReclaimAdjustedAmount`|[`Amount`](#amount-schema)|-|Total reclaim adjusted amount.|
-|`totalReclaimPostedAmount`|[`Amount`](#amount-schema)|-|Total reclaim posted amount.|
-|`totalTaxAdjustedAmount`|[`Amount`](#amount-schema)|-|Total tax adjusted amount.|
-|`totalTaxPostedAmount`|[`Amount`](#amount-schema)|-|Total tax posted amount.|
-|`vatTaxTotal`|[`Amount`](#amount-schema)|-|VAT tax total amount.|
+| Name                         | Type                       | Format | Description                    |
+|------------------------------|----------------------------|--------|--------------------------------|
+| `netAdjustedTaxAmount`       | [`Amount`](#amount-schema) | -      | Net adjusted tax amount.       |
+| `netReclaimAdjustedAmount`   | [`Amount`](#amount-schema) | -      | Net reclaim adjusted amount.   |
+| `netReclaimAmount`           | [`Amount`](#amount-schema) | -      | Net reclaim amount.            |
+| `netTaxAmount`               | [`Amount`](#amount-schema) | -      | Net tax amount.                |
+| `totalReclaimAdjustedAmount` | [`Amount`](#amount-schema) | -      | Total reclaim adjusted amount. |
+| `totalReclaimPostedAmount`   | [`Amount`](#amount-schema) | -      | Total reclaim posted amount.   |
+| `totalTaxAdjustedAmount`     | [`Amount`](#amount-schema) | -      | Total tax adjusted amount.     |
+| `totalTaxPostedAmount`       | [`Amount`](#amount-schema) | -      | Total tax posted amount.       |
+| `vatTaxTotal`                | [`Amount`](#amount-schema) | -      | VAT tax total amount.          |
 
 ### <a name="expense-type-schema"></a>ExpenseType
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`code`|`string`|-|The code of the expense type.|
-|`id`|`string`|-|**Required** The unique identifier of the expense type. Maximum length: 5 characters. Example: `BRKFT`|
-|`isDeleted`|`boolean`|`true`/`false`|Whether the expense type returned is deleted or not.|
-|`name`|`string`|-|The name of the expense type (localized as per `accept-language` header).|
+| Name        | Type      | Format         | Description                                                                                            |
+|-------------|-----------|----------------|--------------------------------------------------------------------------------------------------------|
+| `code`      | `string`  | -              | The code of the expense type.                                                                          |
+| `id`        | `string`  | -              | **Required** The unique identifier of the expense type. Maximum length: 5 characters. Example: `BRKFT` |
+| `isDeleted` | `boolean` | `true`/`false` | Whether the expense type returned is deleted or not.                                                   |
+| `name`      | `string`  | -              | The name of the expense type (localized as per `accept-language` header).                              |
 
 ### <a name="location-schema"></a>Location
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`city`|`string`|-|The location city.|
-|`countryCode`|`string`|-|The location country ISO 3166-1 code.|
-|`countrySubDivisionCode`|`string`|-|The location country sub division ISO 3166-2 code.|
-|`id`|`string`|-|The unique identifier of the location. When location id is specified (when creating or updating a resource), other location object fields will be ignored.|
-|`name`|`string`|-|The location name (localized as per `accept-language` header).|
+| Name                     | Type     | Format | Description                                                                                                                                                |
+|--------------------------|----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `city`                   | `string` | -      | The location city.                                                                                                                                         |
+| `countryCode`            | `string` | -      | The location country ISO 3166-1 code.                                                                                                                      |
+| `countrySubDivisionCode` | `string` | -      | The location country sub division ISO 3166-2 code.                                                                                                         |
+| `id`                     | `string` | -      | The unique identifier of the location. When location id is specified (when creating or updating a resource), other location object fields will be ignored. |
+| `name`                   | `string` | -      | The location name (localized as per `accept-language` header).                                                                                             |
 
 ### <a name="mileage-schema"></a>Mileage
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`hasCaravanAttached`|`boolean`|`true`/`false`|Whether the mileage expense has caravan or trailer attached to the car. Default: `false`|
-|`hasDogIncluded`|`boolean`|`true`/`false`|Whether the mileage expense includes a dog for work purposes. Default: `false`|
-|`hasForestOrConstructionSiteRoadInRoute`|`boolean`|`true`/`false`|Whether the mileage route is via a forest road or construction site road. Default: `false`|
-|`hasForestRoadInRoute`|`boolean`|`true`/`false`|Whether the mileage route has forest road. Default: `false`|
-|`hasMachinery`|`boolean`|`true`/`false`|Whether machines or equipment are transported in the car for this mileage expenses. Default: `false`|
-|`hasMobileCanteenOrHeavyLoadAttached`|`boolean`|`true`/`false`|Whether the mileage expense has mobile canteen or is transporting a heavy load attached to the car. Default: `false`|
-|`hasTrailerAttached`|`boolean`|`true`/`false`|Whether the mileage expense has trailer attached to the car. Default: `false`|
-|`isMarkedAsHigherRate`|`boolean`|`true`/`false`|Whether a higher rate should be applied to the mileage expense. Default: `false`|
-|`odometerEnd`|`integer`|`int32`|The odometer reading at the end of the journey.|
-|`odometerStart`|`integer`|`int32`|The odometer reading at the start of the journey.|
-|`passengerCount`|`integer`|`int32`|The number of passengers in the vehicle during the journey.|
-|`personalDistance`|`integer`|`int32`|The portion of the journey attributed to personal use. Default: `0`|
-|`routeId`|`string`|-|The unique identifier of the route for this journey.|
-|`totalDistance`|`integer`|`int32`|**Required** The total distance for this journey.|
-|`vehicleId`|`string`|-|**Required** The unique identifier for the vehicle used for this journey.|
+| Name                                     | Type      | Format         | Description                                                                                                          |
+|------------------------------------------|-----------|----------------|----------------------------------------------------------------------------------------------------------------------|
+| `hasCaravanAttached`                     | `boolean` | `true`/`false` | Whether the mileage expense has caravan or trailer attached to the car. Default: `false`                             |
+| `hasDogIncluded`                         | `boolean` | `true`/`false` | Whether the mileage expense includes a dog for work purposes. Default: `false`                                       |
+| `hasForestOrConstructionSiteRoadInRoute` | `boolean` | `true`/`false` | Whether the mileage route is via a forest road or construction site road. Default: `false`                           |
+| `hasForestRoadInRoute`                   | `boolean` | `true`/`false` | Whether the mileage route has forest road. Default: `false`                                                          |
+| `hasMachinery`                           | `boolean` | `true`/`false` | Whether machines or equipment are transported in the car for this mileage expenses. Default: `false`                 |
+| `hasMobileCanteenOrHeavyLoadAttached`    | `boolean` | `true`/`false` | Whether the mileage expense has mobile canteen or is transporting a heavy load attached to the car. Default: `false` |
+| `hasTrailerAttached`                     | `boolean` | `true`/`false` | Whether the mileage expense has trailer attached to the car. Default: `false`                                        |
+| `isMarkedAsHigherRate`                   | `boolean` | `true`/`false` | Whether a higher rate should be applied to the mileage expense. Default: `false`                                     |
+| `odometerEnd`                            | `integer` | `int32`        | The odometer reading at the end of the journey.                                                                      |
+| `odometerStart`                          | `integer` | `int32`        | The odometer reading at the start of the journey.                                                                    |
+| `passengerCount`                         | `integer` | `int32`        | The number of passengers in the vehicle during the journey.                                                          |
+| `personalDistance`                       | `integer` | `int32`        | The portion of the journey attributed to personal use. Default: `0`                                                  |
+| `routeId`                                | `string`  | -              | The unique identifier of the route for this journey.                                                                 |
+| `totalDistance`                          | `integer` | `int32`        | **Required** The total distance for this journey.                                                                    |
+| `vehicleId`                              | `string`  | -              | **Required** The unique identifier for the vehicle used for this journey.                                            |
 
 ### <a name="payment-type-schema"></a>PaymentType
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`code`|`string`|-|The code of the payment type.|
-|`id`|`string`|-|**Required** The unique identifier of the payment type. Maximum length: 4 characters. Example: `CASH`|
-|`name`|`string`|-|The name of the payment type (localized as per `accept-language` header).|
+| Name   | Type     | Format | Description                                                                                           |
+|--------|----------|--------|-------------------------------------------------------------------------------------------------------|
+| `code` | `string` | -      | The code of the payment type.                                                                         |
+| `id`   | `string` | -      | **Required** The unique identifier of the payment type. Maximum length: 4 characters. Example: `CASH` |
+| `name` | `string` | -      | The name of the payment type (localized as per `accept-language` header).                             |
 
 ### <a name="receipt-type-schema"></a>ReceiptType
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|**Required** The unique identifier for the receipt type. Supported values: `N` - No Receipt, `R` - Regular Receipt, `T` - Tax Receipt. Default value: `N`|
-|`status`|`string`|-|Receipt status (localized as per `accept-language` header).|
+| Name     | Type     | Format | Description                                                                                                                                               |
+|----------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`     | `string` | -      | **Required** The unique identifier for the receipt type. Supported values: `N` - No Receipt, `R` - Regular Receipt, `T` - Tax Receipt. Default value: `N` |
+| `status` | `string` | -      | Receipt status (localized as per `accept-language` header).                                                                                               |
 
 ### <a name="travel-schema"></a>Travel
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`airlineFeeTypeCode`|`string`|-|Airline fee type code. Supported values: `BAGGS`, `BUSIN`, `OBENT`, `ONBRD`, `OTHER`, `PRACC`, `SEATS`, `TKCHG`, `UPGRD`|
-|`airlineFeeTypeName`|`string`|-|The localized airline fee type name.|
-|`airlineServiceClassCode`|`string`|-|The airline service class code. Supported values: `BUSIN`, `COACH`, `FIRST`|
-|`airlineServiceClassName`|`string`|-|The localized airline service class name.|
-|`carRentalDays`|`integer`|`int32`|The number of days car was rented. Minimum value: `0`|
-|`endLocation`|`string`|-|Location where the travel ended. Maximum length: 100 characters|
-|`hotelCheckinDate`|`string`|`YYYY-MM-DD`|The hotel checkin date of the expense.|
-|`hotelCheckoutDate`|`string`|`YYYY-MM-DD`|The hotel checkout date of the expense.|
-|`startLocation`|`string`|-|Location where the travel started. Maximum length: 100 characters|
-|`ticketNumber`|`string`|-|The ticket number associated with the travel. Maximum length: 32 characters|
+| Name                      | Type      | Format       | Description                                                                                                              |
+|---------------------------|-----------|--------------|--------------------------------------------------------------------------------------------------------------------------|
+| `airlineFeeTypeCode`      | `string`  | -            | Airline fee type code. Supported values: `BAGGS`, `BUSIN`, `OBENT`, `ONBRD`, `OTHER`, `PRACC`, `SEATS`, `TKCHG`, `UPGRD` |
+| `airlineFeeTypeName`      | `string`  | -            | The localized airline fee type name.                                                                                     |
+| `airlineServiceClassCode` | `string`  | -            | The airline service class code. Supported values: `BUSIN`, `COACH`, `FIRST`                                              |
+| `airlineServiceClassName` | `string`  | -            | The localized airline service class name.                                                                                |
+| `carRentalDays`           | `integer` | `int32`      | The number of days car was rented. Minimum value: `0`                                                                    |
+| `endLocation`             | `string`  | -            | Location where the travel ended. Maximum length: 100 characters                                                          |
+| `hotelCheckinDate`        | `string`  | `YYYY-MM-DD` | The hotel checkin date of the expense.                                                                                   |
+| `hotelCheckoutDate`       | `string`  | `YYYY-MM-DD` | The hotel checkout date of the expense.                                                                                  |
+| `startLocation`           | `string`  | -            | Location where the travel started. Maximum length: 100 characters                                                        |
+| `ticketNumber`            | `string`  | -            | The ticket number associated with the travel. Maximum length: 32 characters                                              |
 
 ### <a name="travel-allowance-schema"></a>TravelAllowance
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`dailyLimitAmount`|`number`|`double`|The allowed amount based on government travel allowance rates.|
-|`dailyTravelAllowanceId`|`string`|-|The fixed daily travel allowance ID associated with the expense. Maximum length: 32 characters|
-|`isExpensePartOfTravelAllowance`|`boolean`|`true`/`false`|Whether the expense is part of travel allowance. Default value: `false`|
+| Name                             | Type      | Format         | Description                                                                                    |
+|----------------------------------|-----------|----------------|------------------------------------------------------------------------------------------------|
+| `dailyLimitAmount`               | `number`  | `double`       | The allowed amount based on government travel allowance rates.                                 |
+| `dailyTravelAllowanceId`         | `string`  | -              | The fixed daily travel allowance ID associated with the expense. Maximum length: 32 characters |
+| `isExpensePartOfTravelAllowance` | `boolean` | `true`/`false` | Whether the expense is part of travel allowance. Default value: `false`                        |
 
 ### <a name="vendor-schema"></a>Vendor
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`description`|`string`|-|The description of the vendor. Maximum length: 64 characters|
-|`id`|`string`|-|The unique identifier of the vendor.|
-|`name`|`string`|-|The name of the vendor (localized as per `accept-language` header).|
+| Name          | Type     | Format | Description                                                         |
+|---------------|----------|--------|---------------------------------------------------------------------|
+| `description` | `string` | -      | The description of the vendor. Maximum length: 64 characters        |
+| `id`          | `string` | -      | The unique identifier of the vendor.                                |
+| `name`        | `string` | -      | The name of the vendor (localized as per `accept-language` header). |
 
 ### <a name="update-report-expense-schema"></a>UpdateReportExpense
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`approverAdjustedAmount`|[`Amount`](#amount-schema)|-|The total amount adjusted for the expense by the approver.|
-|`authorizationRequestExpenseId`|`string`|-|The authorization request expense ID associated with the expense.|
-|`budgetAccrualDate`|`string`|`YYYY-MM-DD`|The budget accrual date.|
-|`businessPurpose`|`string`|-|The text input for the business purpose by the user. Maximum length: 64 characters|
-|`comment`|`string`|-|A comment that describes the expense. Maximum length: 2000 characters|
-|`customData`|[`CustomData`](#custom-data-schema)|-|The details from the `customData` fields. These fields may not have data, depending on the configuration.|
-|`exchangeRate`|[`ExchangeRate`](#exchange-rate-schema)|-|The exchange rate data for the expense.|
-|`expenseSource`|`string`|-|**Required** The source of the expense. Supported values: `EA` - Expense Assistant, `MOB` - Mobile, `OTHER` - Unknown, `SE` - Smart Expense, `TA` - Travel Allowance, `TR` - Travel Request, `UI` - Web UI|
-|`expenseType`|[`ExpenseType`](#expense-type-schema)|-|The expense type data for the expense.|
-|`fuelTypeListItem`|[`CustomData`](#custom-data-schema)|-| The unique id of Fuel Type.|
-|`hasMissingReceiptDeclaration`|`boolean`|`true`/`false`|Whether the expense has an affidavit declaration for missing receipt.|
-|`isCopyDownInherited`|`boolean`|`true`/`false`|If `true`, any change in the report expense fields will be copied down to itemizations and allocations, as per the configuration.|
-|`isExcludedFromCashAdvanceByUser`|`boolean`|`true`/`false`|Whether the user has excluded the expense from cash advance.|
-|`isExpenseBillable`|`boolean`|`true`/`false`|Whether the expense is billable.|
-|`isExpenseRejected`|`boolean`|`true`/`false`|Whether the approver or processor has rejected this expense in the report. If `true`, then this expense will be sent back to the report submitted in an addendum (split) report.|
-|`isPaperReceiptReceived`|`boolean`|`true`/`false`|Whether paper receipts have been received for the expense.|
-|`isPersonalExpense`|`boolean`|`true`/`false`|Whether the expense is marked as personal (non-reimbursable) by the user.|
-|`jptRouteId`|`string`|-|The unique route ID to identify a Japan rail route.|
-|`location`|[`Location`](#location-schema)|-|The location data of the expense.|
-|`merchantTaxId`|`string`|-|The merchant tax ID for the expense. Maximum length: 64 characters|
-|`mileage`|[`Mileage`](#mileage-schema)|-|The mileage data associated with the expense.|
-|`paymentType`|[`PaymentType`](#payment-type-schema)|-|The payment type data for the expense. Default: `CASH` |
-|`receiptImageId`|`string`|-|The unique identifier of the image associated with the expense.|
-|`receiptType`|[`ReceiptType`](#receipt-type-schema)|-|Receipt type for the expense.|
-|`smartExpense`|[`SmartExpense`](#smart-expense-schema)|-|The smart expense data associated with this expense.|
-|`tax`|[`Tax`](#tax-schema)|-|The tax data associated with the expense.|
-|`taxRateLocation`|`string`|-|Transaction location relative to the employee's home location as defined by their user profile. Supported values: `FOREIGN` - The expense transaction took place in foreign currency, `HOME` - The expense transaction took place in the reimbursement currency, `OUT_OF_PROVINCE` - The expense transaction took place outside the state jurisdiction|
-|`transactionAmount`|[`Amount`](#amount-schema)|-|The amount of the expense, in the transaction currency paid to the vendor.|
-|`transactionDate`|`string`|`YYYY-MM-DD`|The transaction date (ISO-8601) of the expense.|
-|`travel`|[`Travel`](#travel-schema)|-|The travel data associated with the expense.|
-|`travelAllowance`|[`TravelAllowance`](#travel-allowance-schema)|-|The travel allowance data associated with the expense.|
-|`vendor`|[`Vendor`](#vendor-schema)|-|The vendor data for the expense.|
+| Name                              | Type                                          | Format         | Description                                                                                                                                                                                                                                                                                                                                            |
+|-----------------------------------|-----------------------------------------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `approverAdjustedAmount`          | [`Amount`](#amount-schema)                    | -              | The total amount adjusted for the expense by the approver.                                                                                                                                                                                                                                                                                             |
+| `authorizationRequestExpenseId`   | `string`                                      | -              | The authorization request expense ID associated with the expense.                                                                                                                                                                                                                                                                                      |
+| `budgetAccrualDate`               | `string`                                      | `YYYY-MM-DD`   | The budget accrual date.                                                                                                                                                                                                                                                                                                                               |
+| `businessPurpose`                 | `string`                                      | -              | The text input for the business purpose by the user. Maximum length: 64 characters                                                                                                                                                                                                                                                                     |
+| `comment`                         | `string`                                      | -              | A comment that describes the expense. Maximum length: 2000 characters                                                                                                                                                                                                                                                                                  |
+| `customData`                      | [`CustomData`](#custom-data-schema)           | -              | The details from the `customData` fields. These fields may not have data, depending on the configuration.                                                                                                                                                                                                                                              |
+| `exchangeRate`                    | [`ExchangeRate`](#exchange-rate-schema)       | -              | The exchange rate data for the expense.                                                                                                                                                                                                                                                                                                                |
+| `expenseSource`                   | `string`                                      | -              | **Required** The source of the expense. Supported values: `EA` - Expense Assistant, `MOB` - Mobile, `OTHER` - Unknown, `SE` - Smart Expense, `TA` - Travel Allowance, `TR` - Travel Request, `UI` - Web UI                                                                                                                                             |
+| `expenseType`                     | [`ExpenseType`](#expense-type-schema)         | -              | The expense type data for the expense.                                                                                                                                                                                                                                                                                                                 |
+| `fuelTypeListItem`                | [`CustomData`](#custom-data-schema)           | -              | The unique id of Fuel Type.                                                                                                                                                                                                                                                                                                                            |
+| `hasMissingReceiptDeclaration`    | `boolean`                                     | `true`/`false` | Whether the expense has an affidavit declaration for missing receipt.                                                                                                                                                                                                                                                                                  |
+| `isCopyDownInherited`             | `boolean`                                     | `true`/`false` | If `true`, any change in the report expense fields will be copied down to itemizations and allocations, as per the configuration.                                                                                                                                                                                                                      |
+| `isExcludedFromCashAdvanceByUser` | `boolean`                                     | `true`/`false` | Whether the user has excluded the expense from cash advance.                                                                                                                                                                                                                                                                                           |
+| `isExpenseBillable`               | `boolean`                                     | `true`/`false` | Whether the expense is billable.                                                                                                                                                                                                                                                                                                                       |
+| `isExpenseRejected`               | `boolean`                                     | `true`/`false` | Whether the approver or processor has rejected this expense in the report. If `true`, then this expense will be sent back to the report submitted in an addendum (split) report.                                                                                                                                                                       |
+| `isPaperReceiptReceived`          | `boolean`                                     | `true`/`false` | Whether paper receipts have been received for the expense.                                                                                                                                                                                                                                                                                             |
+| `isPersonalExpense`               | `boolean`                                     | `true`/`false` | Whether the expense is marked as personal (non-reimbursable) by the user.                                                                                                                                                                                                                                                                              |
+| `jptRouteId`                      | `string`                                      | -              | The unique route ID to identify a Japan rail route.                                                                                                                                                                                                                                                                                                    |
+| `location`                        | [`Location`](#location-schema)                | -              | The location data of the expense.                                                                                                                                                                                                                                                                                                                      |
+| `merchantTaxId`                   | `string`                                      | -              | The merchant tax ID for the expense. Maximum length: 64 characters                                                                                                                                                                                                                                                                                     |
+| `mileage`                         | [`Mileage`](#mileage-schema)                  | -              | The mileage data associated with the expense.                                                                                                                                                                                                                                                                                                          |
+| `paymentType`                     | [`PaymentType`](#payment-type-schema)         | -              | The payment type data for the expense. Default: `CASH`                                                                                                                                                                                                                                                                                                 |
+| `receiptImageId`                  | `string`                                      | -              | The unique identifier of the image associated with the expense.                                                                                                                                                                                                                                                                                        |
+| `receiptType`                     | [`ReceiptType`](#receipt-type-schema)         | -              | Receipt type for the expense.                                                                                                                                                                                                                                                                                                                          |
+| `smartExpense`                    | [`SmartExpense`](#smart-expense-schema)       | -              | The smart expense data associated with this expense.                                                                                                                                                                                                                                                                                                   |
+| `tax`                             | [`Tax`](#tax-schema)                          | -              | The tax data associated with the expense.                                                                                                                                                                                                                                                                                                              |
+| `taxRateLocation`                 | `string`                                      | -              | Transaction location relative to the employee's home location as defined by their user profile. Supported values: `FOREIGN` - The expense transaction took place in foreign currency, `HOME` - The expense transaction took place in the reimbursement currency, `OUT_OF_PROVINCE` - The expense transaction took place outside the state jurisdiction |
+| `transactionAmount`               | [`Amount`](#amount-schema)                    | -              | The amount of the expense, in the transaction currency paid to the vendor.                                                                                                                                                                                                                                                                             |
+| `transactionDate`                 | `string`                                      | `YYYY-MM-DD`   | The transaction date (ISO-8601) of the expense.                                                                                                                                                                                                                                                                                                        |
+| `travel`                          | [`Travel`](#travel-schema)                    | -              | The travel data associated with the expense.                                                                                                                                                                                                                                                                                                           |
+| `travelAllowance`                 | [`TravelAllowance`](#travel-allowance-schema) | -              | The travel allowance data associated with the expense.                                                                                                                                                                                                                                                                                                 |
+| `vendor`                          | [`Vendor`](#vendor-schema)                    | -              | The vendor data for the expense.                                                                                                                                                                                                                                                                                                                       |
 
 ### <a name="smart-expense-schema"></a>SmartExpense
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`creditCardTransactionId`|`string`|-|The unique identifier of the credit card transaction (indexed `transactionId`) associated with the expense.|
-|`ereceipt`|[`EReceipt`](#ereceipt-schema)|-|EReceipt information for the expense.|
-|`expenseAttendees`|[`ExpenseAttendees`](#expense-attendees-schema)|-|The attendee details associated with the smart expense.|
-|`isAutoCreated`|`boolean`|`true`/`false`|Whether this expense is auto-created. This element only applies to POST expense request. Default: `false`|
-|`personalCardTransactionId`|`string`|-|The unique identifier of the personal card transaction associated with the expense.|
-|`quickExpenseId`|`string`|-|The unique identifier of the mobile expense associated with the expense. When `quickExpenseId` is specified, the `exchangeRate.value` field value will be ignored and its value will be read from exchange rate currency service. `exchangeRate.operation` will still be honored.|
-|`trip`|[`Trip`](#schematrip)|-|Trip data associated with the expense.|
+| Name                        | Type                                            | Format         | Description                                                                                                                                                                                                                                                                       |
+|-----------------------------|-------------------------------------------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `creditCardTransactionId`   | `string`                                        | -              | The unique identifier of the credit card transaction (indexed `transactionId`) associated with the expense.                                                                                                                                                                       |
+| `ereceipt`                  | [`EReceipt`](#ereceipt-schema)                  | -              | EReceipt information for the expense.                                                                                                                                                                                                                                             |
+| `expenseAttendees`          | [`ExpenseAttendees`](#expense-attendees-schema) | -              | The attendee details associated with the smart expense.                                                                                                                                                                                                                           |
+| `isAutoCreated`             | `boolean`                                       | `true`/`false` | Whether this expense is auto-created. This element only applies to POST expense request. Default: `false`                                                                                                                                                                         |
+| `personalCardTransactionId` | `string`                                        | -              | The unique identifier of the personal card transaction associated with the expense.                                                                                                                                                                                               |
+| `quickExpenseId`            | `string`                                        | -              | The unique identifier of the mobile expense associated with the expense. When `quickExpenseId` is specified, the `exchangeRate.value` field value will be ignored and its value will be read from exchange rate currency service. `exchangeRate.operation` will still be honored. |
+| `trip`                      | [`Trip`](#schematrip)                           | -              | Trip data associated with the expense.                                                                                                                                                                                                                                            |
 
 ### <a name="tax-schema"></a>Tax
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`expenseTax1`|[`ExpenseTax`](#expense-tax-schema)|-|**Required** The tax data for the expense.|
-|`expenseTax2`|[`ExpenseTax`](#expense-tax-schema)|-|The tax data for the expense.|
+| Name          | Type                                | Format | Description                                |
+|---------------|-------------------------------------|--------|--------------------------------------------|
+| `expenseTax1` | [`ExpenseTax`](#expense-tax-schema) | -      | **Required** The tax data for the expense. |
+| `expenseTax2` | [`ExpenseTax`](#expense-tax-schema) | -      | The tax data for the expense.              |
 
 ### <a name="expense-tax-schema"></a>ExpenseTax
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`customData`|[CustomData](#custom-data-schema)|-|The details from the `customData` fields. These fields may not have data, depending on the configuration.|
-|`reclaimCode`|`string`|-|The tax reclaim code. Maximum length: 20 characters|
-|`reclaimTransactionAmount`|`number`|`double`|The tax reclaim transaction amount.|
-|`taxAuthorityId`|`string`|-|**Required** The unique identifier of the tax authority.|
-|`taxAuthorityName`|`string`|-|The name of the tax authority.|
-|`taxCode`|`string`|-|The tax code. Maximum length: 20 characters|
-|`taxFormId`|`string`|-|The unique identifier of the tax form associated with the expense.|
-|`taxLabel`|`string`|-|The localized label of the tax authority.|
-|`taxRateTypeId`|`string`|-|The unique identifier of the tax rate type ID.|
-|`taxRateTypeName`|`string`|-|The name of the tax rate type.|
-|`taxReclaimConfigurationId`|`string`|-|The unique identifier of the tax reclaim configuration ID.|
-|`taxTransactionAmount`|`number`|`double`|The tax transaction amount.|
+| Name                        | Type                              | Format   | Description                                                                                               |
+|-----------------------------|-----------------------------------|----------|-----------------------------------------------------------------------------------------------------------|
+| `customData`                | [CustomData](#custom-data-schema) | -        | The details from the `customData` fields. These fields may not have data, depending on the configuration. |
+| `reclaimCode`               | `string`                          | -        | The tax reclaim code. Maximum length: 20 characters                                                       |
+| `reclaimTransactionAmount`  | `number`                          | `double` | The tax reclaim transaction amount.                                                                       |
+| `taxAuthorityId`            | `string`                          | -        | **Required** The unique identifier of the tax authority.                                                  |
+| `taxAuthorityName`          | `string`                          | -        | The name of the tax authority.                                                                            |
+| `taxCode`                   | `string`                          | -        | The tax code. Maximum length: 20 characters                                                               |
+| `taxFormId`                 | `string`                          | -        | The unique identifier of the tax form associated with the expense.                                        |
+| `taxLabel`                  | `string`                          | -        | The localized label of the tax authority.                                                                 |
+| `taxRateTypeId`             | `string`                          | -        | The unique identifier of the tax rate type ID.                                                            |
+| `taxRateTypeName`           | `string`                          | -        | The name of the tax rate type.                                                                            |
+| `taxReclaimConfigurationId` | `string`                          | -        | The unique identifier of the tax reclaim configuration ID.                                                |
+| `taxTransactionAmount`      | `number`                          | `double` | The tax transaction amount.                                                                               |
 
 ### <a name="ereceipt-schema"></a>EReceipt
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`carEReceipt`|[`CarEReceipt`](#car-receipt-schema)|-|The eReceipt car data.|
-|`hotelEReceipt`|[`HotelEReceipt`](#hotel-receipt-schema)|-|The eReceipt hotel data.|
-|`id`|`string`|-|**Required** The unique identifier of the eReceipt with the expense.|
-|`imageId`|`string`|-|The unique identifier of the eReceipt image associated with the expense.|
-|`templateURL`|`string`|-|The URL of the eReceipt template. Maximum length: 512 characters|
-|`type`|`string`|-|**Required** The type of eReceipt associated with the expense. Supported values: `AIR`, `CAR`, `GASXX`, `GENERAL`, `GRTRN`, `HOTEL`, `JPT`, `MEALS`, `OFFIC`, `PRKNG`, `RAIL`, `RIDE`, `SHIPG`, `TELEC`|
+| Name            | Type                                     | Format | Description                                                                                                                                                                                             |
+|-----------------|------------------------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `carEReceipt`   | [`CarEReceipt`](#car-receipt-schema)     | -      | The eReceipt car data.                                                                                                                                                                                  |
+| `hotelEReceipt` | [`HotelEReceipt`](#hotel-receipt-schema) | -      | The eReceipt hotel data.                                                                                                                                                                                |
+| `id`            | `string`                                 | -      | **Required** The unique identifier of the eReceipt with the expense.                                                                                                                                    |
+| `imageId`       | `string`                                 | -      | The unique identifier of the eReceipt image associated with the expense.                                                                                                                                |
+| `templateURL`   | `string`                                 | -      | The URL of the eReceipt template. Maximum length: 512 characters                                                                                                                                        |
+| `type`          | `string`                                 | -      | **Required** The type of eReceipt associated with the expense. Supported values: `AIR`, `CAR`, `GASXX`, `GENERAL`, `GRTRN`, `HOTEL`, `JPT`, `MEALS`, `OFFIC`, `PRKNG`, `RAIL`, `RIDE`, `SHIPG`, `TELEC` |
 
 ### <a name="hotel-ereceipt-schema"></a>HotelEReceipt
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`calculatedDailyRate`|`number`|`double`|The calculated hotel daily rate.|
-|`endDate`|`string`|`YYYY-MM-DD`|The hotel checkout date.|
-|`locationId`|`string`|-|The unique identifier of the location for this hotel.|
-|`startDate`|`string`|`YYYY-MM-DD`|The hotel check-in date.|
-|`totalAmountPaid`|[`Amount`](#amount-schema)|-|The total amount paid.|
-|`vendorName`|`string`|-|The name of the hotel vendor. Maximum length: 255 characters. Examples: `Hilton`, `Four Points by Sheraton, Seattle`|
+| Name                  | Type                       | Format       | Description                                                                                                          |
+|-----------------------|----------------------------|--------------|----------------------------------------------------------------------------------------------------------------------|
+| `calculatedDailyRate` | `number`                   | `double`     | The calculated hotel daily rate.                                                                                     |
+| `endDate`             | `string`                   | `YYYY-MM-DD` | The hotel checkout date.                                                                                             |
+| `locationId`          | `string`                   | -            | The unique identifier of the location for this hotel.                                                                |
+| `startDate`           | `string`                   | `YYYY-MM-DD` | The hotel check-in date.                                                                                             |
+| `totalAmountPaid`     | [`Amount`](#amount-schema) | -            | The total amount paid.                                                                                               |
+| `vendorName`          | `string`                   | -            | The name of the hotel vendor. Maximum length: 255 characters. Examples: `Hilton`, `Four Points by Sheraton, Seattle` |
 
 ### <a name="car-ereceipt-schema"></a>CarEReceipt
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`calculatedDailyRate`|`number`|`double`|The calculated car rental daily rate.|
-|`carClass`|`string`|-|The car class. Maximum length: 4 characters. Examples: `IDAD`, `ECMZ`, `PCAV`, `IGDV`|
-|`currencyCode`|`string`|-|The 3-letter ISO 4217 currency code. Examples: `USD` - US dollars, `BRL` - Brazilian real, `CAD` - Canadian dollar|
-|`endDate`|`string`|`YYYY-MM-DD`|The car rental end date.|
-|`fuelServiceCharge`|`number`|`double`|The fuel service charge. Minimum value: 0|
-|`numberOfRentalDays`|`integer`|`int32`|The number of car rental calculated days. Minimum value: 0|
-|`startDate`|`string`|`YYYY-MM-DD`|The car rental start date.|
-|`unitsDriven`|`integer`|`int32`|The total units driven. Minimum value: 0|
-|`vendorName`|`string`|-|The name of the car vendor. Maximum length: 255 characters. Example: `ABC Rent A Car`|
+| Name                  | Type      | Format       | Description                                                                                                        |
+|-----------------------|-----------|--------------|--------------------------------------------------------------------------------------------------------------------|
+| `calculatedDailyRate` | `number`  | `double`     | The calculated car rental daily rate.                                                                              |
+| `carClass`            | `string`  | -            | The car class. Maximum length: 4 characters. Examples: `IDAD`, `ECMZ`, `PCAV`, `IGDV`                              |
+| `currencyCode`        | `string`  | -            | The 3-letter ISO 4217 currency code. Examples: `USD` - US dollars, `BRL` - Brazilian real, `CAD` - Canadian dollar |
+| `endDate`             | `string`  | `YYYY-MM-DD` | The car rental end date.                                                                                           |
+| `fuelServiceCharge`   | `number`  | `double`     | The fuel service charge. Minimum value: 0                                                                          |
+| `numberOfRentalDays`  | `integer` | `int32`      | The number of car rental calculated days. Minimum value: 0                                                         |
+| `startDate`           | `string`  | `YYYY-MM-DD` | The car rental start date.                                                                                         |
+| `unitsDriven`         | `integer` | `int32`      | The total units driven. Minimum value: 0                                                                           |
+| `vendorName`          | `string`  | -            | The name of the car vendor. Maximum length: 255 characters. Example: `ABC Rent A Car`                              |
 
 ### <a name="expense-attendee-schema"></a>ExpenseAttendee
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`associatedAttendeeCount`|`integer`|`int32`|The count of total attendees. A count greater than one (1) means there are unnamed attendees associated with this expense-attendee record. Default : `1`|
-|`attendeeId`|`string`|-|**Required** The unique identifier of the associated expense attendee within SAP Concur solutions.|
-|`customData`|[`CustomData`](#custom-data-schema)|-|The details from the `customData` fields. These fields may not have data, depending on the configuration.|
-|`isAmountUserEdited`|`boolean`|`true`/`false`|This field indicates if the amount value for the attendee on this expense was ever manually edited by the end user. Default: `false`|
-|`isTraveling`|`boolean`|`true`/`false`|Whether the attendee was traveling when the expense was incurred. Used for FBT tax calculations.|
-|`transactionAmount`|`number`|`double`|The portion of the expense transaction amount assigned to this attendee for both individual expense tracking and attendee totals across time periods.|
-|`versionNumber`|`integer`|`int32`|The version number of the attendee. This field value may always be one (1), depending on the configuration. Default: `1`|
+| Name                      | Type                                | Format         | Description                                                                                                                                              |
+|---------------------------|-------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `associatedAttendeeCount` | `integer`                           | `int32`        | The count of total attendees. A count greater than one (1) means there are unnamed attendees associated with this expense-attendee record. Default : `1` |
+| `attendeeId`              | `string`                            | -              | **Required** The unique identifier of the associated expense attendee within SAP Concur solutions.                                                       |
+| `customData`              | [`CustomData`](#custom-data-schema) | -              | The details from the `customData` fields. These fields may not have data, depending on the configuration.                                                |
+| `isAmountUserEdited`      | `boolean`                           | `true`/`false` | This field indicates if the amount value for the attendee on this expense was ever manually edited by the end user. Default: `false`                     |
+| `isTraveling`             | `boolean`                           | `true`/`false` | Whether the attendee was traveling when the expense was incurred. Used for FBT tax calculations.                                                         |
+| `transactionAmount`       | `number`                            | `double`       | The portion of the expense transaction amount assigned to this attendee for both individual expense tracking and attendee totals across time periods.    |
+| `versionNumber`           | `integer`                           | `int32`        | The version number of the attendee. This field value may always be one (1), depending on the configuration. Default: `1`                                 |
 
 ### <a name="expense-attendees-schema"></a>ExpenseAttendees
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`expenseAttendeeList`|[`ExpenseAttendee`](#expense-attendee-schema)|-|The list of attendees associated with the expense. Maximum attendees: 500|
-|`noShowAttendeeCount`|`integer`|`int32`|The number of attendees that were planned but did not show up. Default value: `0`|
+| Name                  | Type                                          | Format  | Description                                                                       |
+|-----------------------|-----------------------------------------------|---------|-----------------------------------------------------------------------------------|
+| `expenseAttendeeList` | [`ExpenseAttendee`](#expense-attendee-schema) | -       | The list of attendees associated with the expense. Maximum attendees: 500         |
+| `noShowAttendeeCount` | `integer`                                     | `int32` | The number of attendees that were planned but did not show up. Default value: `0` |
 
 ### <a name="trip-schema"></a>Trip
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`airTrip`|[`AirTrip`](#Air-trip-schema)|-|Air trip data associated with the expense.|
-|`bookingOrigin`|`string`|-|Booking origin of the trip. Supported values: `AETM` - Amadeus E-Travel, `CLIQ` - Concur Travel, `PANM` - Open Booking, `TRPT` - TripIt, `TSUP` - Travel Supplier|
-|`bookingSource`|`string`|-|Booking source of the trip. Maximum length: 48 characters. Examples: `Expedia`, `Travelocity`, `Manual`|
-|`carTrip`|[`CarTrip`](#car-trip-schema)|-|Car trip data associated with the expense.|
-|`cliqbookPaymentId`|`integer`|`int32`|Cliqbook payment ID associated with the trip.|
-|`cliqbookPaymentMethod`|`string`|-|Cliqbook payment method associated with the trip. Supported values: `GHOST_CARD` or `FLGHT_PASS`|
-|`hotelTrip`|[`HotelTrip`](#hotel-trip-schema)|-|Hotel trip data associated with the expense.|
-|`merchantCode`|`string`|-|Merchant code associated with the trip. Maximum length: 4 characters|
-|`rideTrip`|[`RideTrip`](#ride-trip-schema)|-|Ride or taxi trip data associated with the expense.|
-|`segmentId`|`integer`|`int64`|**Required** The unique identifier of the segment associated with the expense.|
-|`segmentTypeId`|`string`|-|**Required** Segment type ID associated with the trip. Supported values: `AIRFR` - Air Ticket, `AIRSU` - Air Subscription, `CARRT` - Car Rental, `DININ` - Dining, `EVENT` - Event, `HOTEL` - Hotel Reservation, `INSUR` - Insurance, `LIMOF` - Limousine Reservation, `MISC` - Miscellaneous, `PARKG` - Parking Fee, `RAILF` - Train Ticket, `RAISU` - Train Subscription, `TAXIF` - Taxi Fare, `VISA` - Visa|
-|`startLocationId`|`string`|-|The unique identifier of the start location associated with the trip.|
-|`tripId`|`integer`|`int64`|**Required** The unique identifier of the trip ID associated with the expense.|
+| Name                    | Type                              | Format  | Description                                                                                                                                                                                                                                                                                                                                                                                                    |
+|-------------------------|-----------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `airTrip`               | [`AirTrip`](#Air-trip-schema)     | -       | Air trip data associated with the expense.                                                                                                                                                                                                                                                                                                                                                                     |
+| `bookingOrigin`         | `string`                          | -       | Booking origin of the trip. Supported values: `AETM` - Amadeus E-Travel, `CLIQ` - Concur Travel, `PANM` - Open Booking, `TRPT` - TripIt, `TSUP` - Travel Supplier                                                                                                                                                                                                                                              |
+| `bookingSource`         | `string`                          | -       | Booking source of the trip. Maximum length: 48 characters. Examples: `Expedia`, `Travelocity`, `Manual`                                                                                                                                                                                                                                                                                                        |
+| `carTrip`               | [`CarTrip`](#car-trip-schema)     | -       | Car trip data associated with the expense.                                                                                                                                                                                                                                                                                                                                                                     |
+| `cliqbookPaymentId`     | `integer`                         | `int32` | Cliqbook payment ID associated with the trip.                                                                                                                                                                                                                                                                                                                                                                  |
+| `cliqbookPaymentMethod` | `string`                          | -       | Cliqbook payment method associated with the trip. Supported values: `GHOST_CARD` or `FLGHT_PASS`                                                                                                                                                                                                                                                                                                               |
+| `hotelTrip`             | [`HotelTrip`](#hotel-trip-schema) | -       | Hotel trip data associated with the expense.                                                                                                                                                                                                                                                                                                                                                                   |
+| `merchantCode`          | `string`                          | -       | Merchant code associated with the trip. Maximum length: 4 characters                                                                                                                                                                                                                                                                                                                                           |
+| `rideTrip`              | [`RideTrip`](#ride-trip-schema)   | -       | Ride or taxi trip data associated with the expense.                                                                                                                                                                                                                                                                                                                                                            |
+| `segmentId`             | `integer`                         | `int64` | **Required** The unique identifier of the segment associated with the expense.                                                                                                                                                                                                                                                                                                                                 |
+| `segmentTypeId`         | `string`                          | -       | **Required** Segment type ID associated with the trip. Supported values: `AIRFR` - Air Ticket, `AIRSU` - Air Subscription, `CARRT` - Car Rental, `DININ` - Dining, `EVENT` - Event, `HOTEL` - Hotel Reservation, `INSUR` - Insurance, `LIMOF` - Limousine Reservation, `MISC` - Miscellaneous, `PARKG` - Parking Fee, `RAILF` - Train Ticket, `RAISU` - Train Subscription, `TAXIF` - Taxi Fare, `VISA` - Visa |
+| `startLocationId`       | `string`                          | -       | The unique identifier of the start location associated with the trip.                                                                                                                                                                                                                                                                                                                                          |
+| `tripId`                | `integer`                         | `int64` | **Required** The unique identifier of the trip ID associated with the expense.                                                                                                                                                                                                                                                                                                                                 |
 
 ### <a name="hotel-trip-schema"></a>HotelTrip
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`calculatedDailyRate`|`number`|`double`|The calculated hotel daily rate.|
-|`endDate`|`string`|`YYYY-MM-DD`|The hotel checkout date.|
-|`numberOfNights`|`integer`|`int32`|The number of nights. Minimum value: `1`|
-|`numberOfRooms`|`integer`|`int32`|The number of hotel rooms. Minimum value: `1`|
-|`startDate`|`string`|`YYYY-MM-DD`|The hotel check-in date.|
-|`totalAmountPaid`|[`Amount`](#amount-schema)|-|The total amount paid.|
-|`vendorName`|`string`|-|The name of the hotel vendor. Maximum length: 255 characters. Examples: `Hilton`, `Four Points by Sheraton, Seattle`|
+| Name                  | Type                       | Format       | Description                                                                                                          |
+|-----------------------|----------------------------|--------------|----------------------------------------------------------------------------------------------------------------------|
+| `calculatedDailyRate` | `number`                   | `double`     | The calculated hotel daily rate.                                                                                     |
+| `endDate`             | `string`                   | `YYYY-MM-DD` | The hotel checkout date.                                                                                             |
+| `numberOfNights`      | `integer`                  | `int32`      | The number of nights. Minimum value: `1`                                                                             |
+| `numberOfRooms`       | `integer`                  | `int32`      | The number of hotel rooms. Minimum value: `1`                                                                        |
+| `startDate`           | `string`                   | `YYYY-MM-DD` | The hotel check-in date.                                                                                             |
+| `totalAmountPaid`     | [`Amount`](#amount-schema) | -            | The total amount paid.                                                                                               |
+| `vendorName`          | `string`                   | -            | The name of the hotel vendor. Maximum length: 255 characters. Examples: `Hilton`, `Four Points by Sheraton, Seattle` |
 
 ### <a name="air-trip-schema"></a>AirTrip
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`airlineName`|`string`|-|The name of the airline vendor. Maximum length: 255 characters. Example: `Alaska Airlines`|
-|`endDate`|`string`|`YYYY-MM-DD`|The last travel date or the travel end date.|
-|`numberOfTravelDays`|`integer`|`int32`|The number of days of travel. Minimum value: `1`|
-|`startDate`|`string`|`YYYY-MM-DD`|The first travel date or the travel start date.|
-|`ticketType`|`string`|-|The airline class of service. Maximum length: 10 characters. Example: `Economy`|
-|`totalAmountPaid`|[`Amount`](#amount-schema)|-|The total amount paid.|
+| Name                 | Type                       | Format       | Description                                                                                |
+|----------------------|----------------------------|--------------|--------------------------------------------------------------------------------------------|
+| `airlineName`        | `string`                   | -            | The name of the airline vendor. Maximum length: 255 characters. Example: `Alaska Airlines` |
+| `endDate`            | `string`                   | `YYYY-MM-DD` | The last travel date or the travel end date.                                               |
+| `numberOfTravelDays` | `integer`                  | `int32`      | The number of days of travel. Minimum value: `1`                                           |
+| `startDate`          | `string`                   | `YYYY-MM-DD` | The first travel date or the travel start date.                                            |
+| `ticketType`         | `string`                   | -            | The airline class of service. Maximum length: 10 characters. Example: `Economy`            |
+| `totalAmountPaid`    | [`Amount`](#amount-schema) | -            | The total amount paid.                                                                     |
 
 ### <a name="ride-trip-schema"></a>RideTrip
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`startDate`|`string`|`YYYY-MM-DD`|The start date for the ride.|
-|`totalAmountPaid`|[`Amount`](#amount-schema)|-|The total amount paid.|
-|`vendorName`|`string`|-|The name of the vendor. Maximum length: 255 characters. Example: `Yellow Cab`|
+| Name              | Type                       | Format       | Description                                                                   |
+|-------------------|----------------------------|--------------|-------------------------------------------------------------------------------|
+| `startDate`       | `string`                   | `YYYY-MM-DD` | The start date for the ride.                                                  |
+| `totalAmountPaid` | [`Amount`](#amount-schema) | -            | The total amount paid.                                                        |
+| `vendorName`      | `string`                   | -            | The name of the vendor. Maximum length: 255 characters. Example: `Yellow Cab` |
 
 ### <a name="car-trip-schema"></a>CarTrip
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`calculatedDailyRate`|`number`|`double`|The calculated car rental daily rate.|
-|`carClass`|`string`|-|The car class. Maximum length: 10 characters. Examples: `IDAD`, `ECMZ`, `PCAV`, `IGDV`|
-|`endDate`|`string`|`YYYY-MM-DD`|The car rental end date.|
-|`numberOfCars`|`integer`|`int32`|The number of cars rented. Minimum value: `1`|
-|`numberOfRentalDays`|`integer`|`int32`|The number of car rental calculated days. Minimum value: `0`|
-|`startDate`|`string`|`YYYY-MM-DD`|The car rental start date.|
-|`totalAmountPaid`|[`Amount`](#amount-schema)|-|The total amount paid.|
-|`vendorName`|`string`|-|The name of the car vendor. Maximum length: 255 characters. Example: `ABC Rent A Car`|
+| Name                  | Type                       | Format       | Description                                                                            |
+|-----------------------|----------------------------|--------------|----------------------------------------------------------------------------------------|
+| `calculatedDailyRate` | `number`                   | `double`     | The calculated car rental daily rate.                                                  |
+| `carClass`            | `string`                   | -            | The car class. Maximum length: 10 characters. Examples: `IDAD`, `ECMZ`, `PCAV`, `IGDV` |
+| `endDate`             | `string`                   | `YYYY-MM-DD` | The car rental end date.                                                               |
+| `numberOfCars`        | `integer`                  | `int32`      | The number of cars rented. Minimum value: `1`                                          |
+| `numberOfRentalDays`  | `integer`                  | `int32`      | The number of car rental calculated days. Minimum value: `0`                           |
+| `startDate`           | `string`                   | `YYYY-MM-DD` | The car rental start date.                                                             |
+| `totalAmountPaid`     | [`Amount`](#amount-schema) | -            | The total amount paid.                                                                 |
+| `vendorName`          | `string`                   | -            | The name of the car vendor. Maximum length: 255 characters. Example: `ABC Rent A Car`  |
 
 ### <a name="link-schema"></a>Link
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`deprecation`|`string`|-|-|
-|`href`|`string`|-|**Required** The URL of the related `HATEOAS` link that you can use for subsequent calls.|
-|`hreflang`|`string`|-|-|
-|`isTemplated`|`boolean`|`true`/`false`|**Required** Whether the `href` is parameterized.|
-|`media`|`string`|-|-|
-|`method`|`string`|-|**Required** The HTTP method required for the related call.|
-|`rel`|`string`|-|**Required** The link relationship that describes how the `href` relates to the API call.|
-|`title`|`string`|-|-|
-|`type`|`string`|-|-|
+| Name          | Type      | Format         | Description                                                                               |
+|---------------|-----------|----------------|-------------------------------------------------------------------------------------------|
+| `deprecation` | `string`  | -              | -                                                                                         |
+| `href`        | `string`  | -              | **Required** The URL of the related `HATEOAS` link that you can use for subsequent calls. |
+| `hreflang`    | `string`  | -              | -                                                                                         |
+| `isTemplated` | `boolean` | `true`/`false` | **Required** Whether the `href` is parameterized.                                         |
+| `media`       | `string`  | -              | -                                                                                         |
+| `method`      | `string`  | -              | **Required** The HTTP method required for the related call.                               |
+| `rel`         | `string`  | -              | **Required** The link relationship that describes how the `href` relates to the API call. |
+| `title`       | `string`  | -              | -                                                                                         |
+| `type`        | `string`  | -              | -                                                                                         |
 
 ### <a name="error-message-schema"></a>ErrorMessage
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`customResponseData`|`object`|-|The custom parameters related to error.|
-|`errorId`|`string`|-|The unique identifier of the error associated with the response.|
-|`errorMessage`|`string`|-|**Required** The detailed error message.|
-|`httpStatus`|`string`|-|**Required** The http response code and phrase for the response.|
-|`path`|`string`|-|**Required** The URI of the attempted request.|
-|`timestamp`|`string`|`date-time`|**Required** The time when the error was captured.|
-|`validationErrors`|[`ValidationError`](#validation-error-schema)|-|The validation error messages.|
+| Name                 | Type                                          | Format      | Description                                                      |
+|----------------------|-----------------------------------------------|-------------|------------------------------------------------------------------|
+| `customResponseData` | `object`                                      | -           | The custom parameters related to error.                          |
+| `errorId`            | `string`                                      | -           | The unique identifier of the error associated with the response. |
+| `errorMessage`       | `string`                                      | -           | **Required** The detailed error message.                         |
+| `httpStatus`         | `string`                                      | -           | **Required** The http response code and phrase for the response. |
+| `path`               | `string`                                      | -           | **Required** The URI of the attempted request.                   |
+| `timestamp`          | `string`                                      | `date-time` | **Required** The time when the error was captured.               |
+| `validationErrors`   | [`ValidationError`](#validation-error-schema) | -           | The validation error messages.                                   |
 
 ### <a name="validation-errors-schema"></a>ValidationError
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|The ID of the validation error.|
-|`message`|`string`|-|The detailed message of the validation error.|
-|`source`|`string`|-|The type of validation which failed.|
+| Name      | Type     | Format | Description                                   |
+|-----------|----------|--------|-----------------------------------------------|
+| `id`      | `string` | -      | The ID of the validation error.               |
+| `message` | `string` | -      | The detailed message of the validation error. |
+| `source`  | `string` | -      | The type of validation which failed.          |

--- a/src/api-reference/expense/expense-report/v4.reports.markdown
+++ b/src/api-reference/expense/expense-report/v4.reports.markdown
@@ -5,7 +5,8 @@ layout: reference
 
 # Reports v4
 
-The Reports v4 API can be used to read and modify an expense report header of an existing expense report. This API can be used to change attributes like report name, business purpose, etc.
+The Reports v4 API can be used to read and modify an expense report header of an existing expense report. This API can
+be used to change attributes like report name, business purpose, etc.
 
 ## Prior Versions <a name="prior-versions"></a>
 
@@ -25,23 +26,24 @@ Access to this documentation does not provide access to the API.
 
 Required Scopes:
 
-| Name|Description| Endpoint    |
-| ---|---|-------------|
-|`expense.report.read`| Get information about expense reports.| GET         |
-|`expense.report.readwrite`|Read and write expense report headers.| PATCH, POST |
-|`expense.report.workflowstatus.write`|Approve or Send Back the Report in the workflow| PATCH       |
-|`user.read`|Get User Information, necessary for `userID`.| GET         |
+| Name                                  | Description                                     | Endpoint    |
+|---------------------------------------|-------------------------------------------------|-------------|
+| `expense.report.read`                 | Get information about expense reports.          | GET         |
+| `expense.report.readwrite`            | Read and write expense report headers.          | PATCH, POST |
+| `expense.report.workflowstatus.write` | Approve or Send Back the Report in the workflow | PATCH       |
+| `user.read`                           | Get User Information, necessary for `userID`.   | GET         |
 
 Optional Scope:
 
-|Name|Description|Endpoint|
-|---|---|---|
-|`spend.listitem.read`|Read only access to spend list items `listItemId`.|GET|
-|`spend.list.read`|Read only access to spend list and category details.|GET|
+| Name                  | Description                                          | Endpoint |
+|-----------------------|------------------------------------------------------|----------|
+| `spend.listitem.read` | Read only access to spend list items `listItemId`.   | GET      |
+| `spend.list.read`     | Read only access to spend list and category details. | GET      |
 
 ## Dependencies <a name="dependencies"></a>
 
-SAP Concur clients must purchase Concur Expense in order to use this API. This API requires the Identity v4 API. Please contact your SAP Concur representative for more information.
+SAP Concur clients must purchase Concur Expense in order to use this API. This API requires the Identity v4 API. Please
+contact your SAP Concur representative for more information.
 
 ## Access Token Usage <a name="access-token-usage"></a>
 
@@ -65,11 +67,11 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-| **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`.                        |
-|`contextType`|`string`|-| **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `MANAGER`, `PROCESSOR`, `PROXY` |
-|`reportId`|string|-| **Required** The unique identifier of the report that is being read.                                                                                                       |
+| Name          | Type     | Format | Description                                                                                                                                                                |
+|---------------|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`.                        |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `MANAGER`, `PROCESSOR`, `PROXY` |
+| `reportId`    | string   | -      | **Required** The unique identifier of the report that is being read.                                                                                                       |
 
 #### Headers
 
@@ -79,7 +81,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
 
 ### Response
 
@@ -247,10 +250,10 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
+| Name          | Type     | Format | Description                                                                                                                                         |
+|---------------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`  |
 
 #### Headers
 
@@ -260,7 +263,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
 
 #### Payload
 
@@ -311,7 +315,7 @@ curl --location --request POST 'https://us.api.concursolutions.com/expensereport
 }
 ```
 
-## Update a Specific Report <a name="update-report-header"></a>
+## Update Unsubmitted Report <a name="update-report-header"></a>
 
 Updates the attributes of a specific report.
 
@@ -329,11 +333,11 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`.|
-|`contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`|
-|`reportId`|string|-|**Required** The unique identifier of the report that is being modified.|
+| Name          | Type     | Format | Description                                                                                                                                         |
+|---------------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userID`      | `string` | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
+| `contextType` | `string` | -      | **Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: `TRAVELER`, `PROXY`  |
+| `reportId`    | string   | -      | **Required** The unique identifier of the report that is being modified.                                                                            |
 
 #### Headers
 
@@ -343,7 +347,8 @@ https://{datacenterURI}/expensereports/v4/users/{userID}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
 
 #### REST Design Specification
 
@@ -392,9 +397,13 @@ curl --location --request PATCH 'https://us.api.concursolutions.com/expenserepor
 204 No Content
 ```
 
-## Update a Submitted Report <a name="update-submitted-report"></a>
+## Update Submitted Report <a name="update-submitted-report"></a>
 
-Updates the report header in an unsubmitted or submitted expense report specified and is restricted to modify `Business Purpose`, `Comment`, `Custom/Org unit`, `Name` and `Paper Receipt Received` fields only (only Company JWT Allowed).
+Updates the report header in an unsubmitted or submitted expense report. When calling this endpoint only Company JWT
+authentication is allowed. Since this endpoint supports updating submitted reports and does not require a user and
+context, only a limited set of fields can be updated through it.
+
+A submitted report cannot be updated even through this endpoint once it has reached a 'Paid' workflow status.
 
 ### Scopes
 
@@ -410,9 +419,9 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`reportId`|`string`|-|**Required** The unique identifier of the report to which this expense entry belongs.|
+| Name       | Type     | Format | Description                                                                           |
+|------------|----------|--------|---------------------------------------------------------------------------------------|
+| `reportId` | `string` | -      | **Required** The unique identifier of the report to which this expense entry belongs. |
 
 #### Headers
 
@@ -422,7 +431,8 @@ https://{datacenterURI}/expensereports/v4/reports/{reportId}
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
 
 #### REST Design Specification
 
@@ -432,7 +442,7 @@ PATCH operations in Expense Reports v4 conform to the JSON Merge Patch specifica
 
 #### Payload
 
-* [Patch Submitted Report Request](#patch-submitted-report-request-schema)
+* [Patch Submitted Report Request](#update-submitted-report-schema)
 
 ### Response
 
@@ -451,26 +461,25 @@ PATCH operations in Expense Reports v4 conform to the JSON Merge Patch specifica
 
 ### <a name="update-report-compact-schema"></a>Update Report Compact Schema
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`businessPurpose`|`string`| - | The text input for the business purpose by the user. Maximum length: 64 characters.|
-|`comment`|`string`| - | The expense report comment added by the user.|
-|`customData` |[`CustomData`](#custom-data-schema) | - | The details from the `customData` fields. These fields may not have data, depending on the configuration.|
-|`name`| `string`  | - | The expense report name input by the user.|
-|`isPaperReceiptsReceived`|`boolean` |`true`/`false` |Whether paper receipts have been received for the report.|
-
+| Name                      | Type                                | Format         | Description                                                                                               |
+|---------------------------|-------------------------------------|----------------|-----------------------------------------------------------------------------------------------------------|
+| `businessPurpose`         | `string`                            | -              | The text input for the business purpose by the user. Maximum length: 64 characters.                       |
+| `comment`                 | `string`                            | -              | The expense report comment added by the user.                                                             |
+| `customData`              | [`CustomData`](#custom-data-schema) | -              | The details from the `customData` fields. These fields may not have data, depending on the configuration. |
+| `name`                    | `string`                            | -              | The expense report name input by the user.                                                                |
+| `isPaperReceiptsReceived` | `boolean`                           | `true`/`false` | Whether paper receipts have been received for the report.                                                 |
 
 #### <a name="report-custom-data-schema"></a>CustomData
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|**Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`|
-|`isValid`|`boolean`|`true`/`false`|Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true`|
-|`value`|`string`|-|The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters|
+| Name      | Type      | Format         | Description                                                                                                                                                                                          |
+|-----------|-----------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`      | `string`  | -              | **Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`                                                                                                              |
+| `isValid` | `boolean` | `true`/`false` | Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true` |
+| `value`   | `string`  | -              | The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters                      |
 
 ### Example
 
-#### <a name="patch-submitted-report-request-schema"></a> Request
+#### <a name="update-submitted-report-schema"></a> Request
 
 ```shell
 curl --location --request PATCH 'https://us.api.concursolutions.com/expensereports/v4/reports/764428DD6A664AF0BFCB' \
@@ -515,13 +524,13 @@ https://{datacenterURI}/expensereports/v4/users/{userId}/context/{contextType}/r
 
 #### Parameters
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`userId`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
-|`contextType`|`string`|-|**Required** The access level of the Concur user, which determines the form fields they can view/modify.|
-|`sort`|`string`|-| The name of the report field on which to sort.|
-|`order`|`string`|-| The order to sort the field by.|
-|`includeDelegateApprovals`|`boolean`|-| Boolean field indicating whether or not include reports you could approve as a delegate.|
+| Name                       | Type      | Format | Description                                                                                                                                         |
+|----------------------------|-----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `userId`                   | `string`  | -      | **Required** The unique identifier of the SAP Concur user. Use [Identity v4 API](/api-reference/profile/v4.identity.html) to retrieve the `userID`. |
+| `contextType`              | `string`  | -      | **Required** The access level of the Concur user, which determines the form fields they can view/modify. Supported values:`MANAGER`                 |
+| `sort`                     | `string`  | -      | The name of the report field on which to sort.                                                                                                      |
+| `order`                    | `string`  | -      | The order to sort the field by.                                                                                                                     |
+| `includeDelegateApprovals` | `boolean` | -      | Boolean field indicating whether or not include reports you could approve as a delegate.                                                            |
 
 #### Headers
 
@@ -531,7 +540,8 @@ https://{datacenterURI}/expensereports/v4/users/{userId}/context/{contextType}/r
 * [RFC 7234 Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
 * [RFC 7232 If-Modified-Since](https://tools.ietf.org/html/rfc7232#section-3.3)
 * [RFC 7231 Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller. This is the Company or User access token.
+* [RFC 7235 Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) - Bearer Token that identifies the caller.
+  This is the Company or User access token.
 
 #### Request
 
@@ -542,6 +552,12 @@ curl --location --request GET https://integration.api.concursolutions.com/expens
 ```
 
 #### Response
+
+#### Payload
+
+[Report To Approve Response Schema](#report-details-schema)
+
+#### Example
 
 ```json
 [
@@ -577,30 +593,6 @@ curl --location --request GET https://integration.api.concursolutions.com/expens
 ]
 ```
 
-#### Exception Response
-
-```json
-{
-  "timestamp": "2023-05-09T15:14:35.296Z",
-  "httpStatus": "string",
-  "errorMessage": "string",
-  "errorId": "string",
-  "validationErrors": [
-    {
-      "source": "string",
-      "message": "string",
-      "id": "string"
-    }
-  ],
-  "customResponseData": {
-    "additionalProp1": "string",
-    "additionalProp2": "string",
-    "additionalProp3": "string"
-  },
-  "path": "string"
-}
-```
-
 #### Status Codes
 
 * [200 OK](https://tools.ietf.org/html/rfc7231#section-6.3.2)
@@ -612,152 +604,188 @@ curl --location --request GET https://integration.api.concursolutions.com/expens
 
 ## Schema <a name="schema"></a>
 
+### <a name="report-to-approve-schema"></a>Report To Approve
+
+| Name                  | Type                           | Format                 | Description                                                                                                                                                                       |
+|-----------------------|--------------------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                | `string`                       | -                      | **Required** The expense report name input by the user.                                                                                                                           |
+| `reportDate`          | `string`                       | `YYYY-MM-DD`           | The date assigned to the report by the user.                                                                                                                                      |
+| `reportId`            | `string`                       | -                      | **Required** The unique identifier for the report resource.                                                                                                                       |
+| `reportNumber`        | `string`                       | -                      | User friendly unique identifier for the report.                                                                                                                                   |
+| `submitDate`          | `string`                       | `YYYY-MM-DDTHH:mm:ssZ` | The UTC datetime when the user submitted the report.                                                                                                                              |
+| `approver`            | [`Employee`](#employee-schema) | -                      | Employee info for the approver of the reports current workflow step                                                                                                               |
+| `employee`            | [`Employee`](#employee-schema) | -                      | Employee info for the owner of the report                                                                                                                                         |
+| `submitDate`          | `string`                       | `YYYY-MM-DD`           | The date (ISO-8601) the report was submitted by the user (https://www.iso.org/iso-8601-date-and-time-format.html).                                                                |
+| `amountDueEmployee`   | [`Amount`](#amount-schema)     | -                      | The amount that the company owes the employee.                                                                                                                                    |
+| `claimedAmount`       | [`Amount`](#amount-schema)     | -                      | The total amount of all non-personal expenses in the report.                                                                                                                      |
+| `totalApprovedAmount` | [`Amount`](#amount-schema)     | -                      | The total approved amount for the report                                                                                                                                          |
+| `hasExceptions`       | `boolean`                      | `true`/`false`         | Whether the Report has any exceptions.                                                                                                                                            |
+| `reportType`          | `string`                       | -                      | This value identifies the method used to create the report. Statement refers to company billed statement reports and auto-created refers to reports created by Expense Assistant. |
+| `links`               | [`Link`](#link-schema)         | -                      | Resource links related to this call.                                                                                                                                              |
+
 ### <a name="report-details-schema"></a>ReportDetails
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`allocationFormId`|`string`|-|The unique identifier of the allocation form.|
-|`amountCompanyPaid`|[`Amount`](#amount-schema)|-|**Required** The amount paid by the company.|
-|`amountDueCompany`|[`Amount`](#amount-schema)|-|**Required** The amount that the employee owes the company.|
-|`amountDueCompanyCard`|[`Amount`](#amount-schema)|-|**Required** The amount that the employee/company owes the corporate card.|
-|`amountDueEmployee`|[`Amount`](#amount-schema)|-|**Required** The amount that the company owes the employee.|
-|`amountNotApproved`|[`Amount`](#amount-schema)|-|**Required** The amount that was not approved for the report.|
-|`analyticsGroupId`|`string`|-|**Required** The unique identifier of the business intelligence hierarchy node.|
-|`approvalStatus`|`string`|-|**Required** The report’s approval status, in the user’s language.|
-|`approvalStatusId`|`string`|-|**Required** The unique identifier of the approval status.|
-|`approvedAmount`|[`Amount`](#amount-schema)|-|**Required** The total amount of approved expenses in the report.|
-|`businessPurpose`|`string`|-|The text input for the business purpose by the user.|
-|`canRecall`|`boolean`|`true`/`false`|**Required** Whether the report can be recalled by the current user.|
-|`canReopen`|`boolean`|`true`/`false`|Whether the report can be reopened after payment.|
-|`cardProgramStatementPeriodId`|`string`|-|The unique identifier of card program statement period on the report.|
-|`claimedAmount`|[`Amount`](#amount-schema)|-|**Required** The total amount of all non-personal expenses in the report.|
-|`concurAuditStatus`|`string`|-|**Required** The status of audit for the report.|
-|`country`|`string`|-|The country name associated with the report (localized as per `accept-language` header).|
-|`countryCode`|`string`|`ISO 3166-1 alpha-2 country code`|The report country. Maximum characters: 2. Example: `US` - United States|
-|`countrySubDivisionCode`|`string`|-|The location country sub division ISO 3166-2 code.|
-|`creationDate`|`string`|`YYYY-MM-DDTHH:mm:ssZ`|**Required** The UTC datetime when the user created the report.|
-|`currency`|`string`|-|**Required** The currency name for the report (localized as per `accept-language` header).|
-|`currencyCode`|`string`|-|**Required** The 3-letter ISO 4217 currency code for the expense report currency. Examples: `USD` - US dollars; `BRL` - Brazilian real; `CAD` - Canadian dollar; `CHF` - Swiss franc; `EUR` - Euro; `GBO` - Pound sterling; `HKD` - Hong Kong|
-|`customData`|[`CustomData`](#custom-data-schema)|-|The details from the `customData` fields. These fields may not have data, depending on the configuration.|
-|`endDate`|`string`|`YYYY-MM-DD`|The end date (ISO-8601) of the report as used for trip-based reporting.|
-|`hierarchyNodeId`|`string`|-|**Required** The unique identifier of the group hierarchy node for the report resource.|
-|`isFinancialIntegrationEnabled`|`boolean`|`true`/`false`|**Required** Whether the Financial Integration setting has been enabled for this report.|
-|`isPaperReceiptsReceived`|`boolean`|`true`/`false`|**Required** Whether paper receipts have been received for the report.|
-|`isReceiptImageAvailable`|`boolean`|`true`/`false`|**Required** Whether the receipt image is available at the report level.|
-|`isReceiptImageRequired`|`boolean`|`true`/`false`|**Required** Whether the receipt image is required at the report level.|
-|`isReopened`|`boolean`|`true`/`false`|Whether the report is reopened.|
-|`ledger`|`string`|-|**Required** The ledger name to which the report belongs (localized as per `accept-language` header).|
-|`ledgerId`|`string`|-|**Required** The unique identifier of the ledger.|
-|`links`|[`Link`](#link-schema)|-|Resource links related to this call.|
-|`name`|`string`|-|**Required** The expense report name input by the user.|
-|`paymentConfirmedAmount`|[`Amount`](#amount-schema)|-|**Required** The amount that was paid on the report.|
-|`paymentStatus`|`string`|-|**Required** The report's payment status in the user's language.|
-|`paymentStatusId`|`string`|-|**Required** The unique identifier of the payment status of the report.|
-|`personalAmount`|[`Amount`](#amount-schema)|-|**Required** The total amount of expenses marked as personal on the report.|
-|`policy`|`string`|-|**Required** The policy name to which the report adheres (localized as per `accept-language` header).|
-|`policyId`|`string`|-|**Required** The unique identifier of the policy that applies to this report.|
-|`redirectFund`|[`RedirectFund`](#redirect-fund)|-|Funds redirected to IBCP card.|
-|`reportDate`|`string`|`YYYY-MM-DD`|The date assigned to the report by the user.|
-|`reportFormId`|`string`|-|**Required** The unique identifier of the report form.|
-|`reportId`|`string`|-|**Required** The unique identifier for the report resource.|
-|`reportNumber`|`string`|-|User friendly unique identifier for the report.|
-|`reportTotal`|[`Amount`](#amount-schema)|-|**Required** The total amount on the report.|
-|`reportType`|`string`|-|This value identifies the method used to create the report. Statement refers to company billed statement reports and auto-created refers to reports created by Expense Assistant.|
-|`reportVersion`|`integer`|`int32`|**Required** The current version of the report.|
-|`startDate`|`string`|`YYYY-MM-DD`|The start date of the report as used for trip-based reporting.|
-|`submitDate`|`string`|`YYYY-MM-DDTHH:mm:ssZ`|The UTC datetime when the user submitted the report.|
-|`submitterId`|`string`|-|The unique identifier of the employee who submitted the report.|
-|`taxConfigId`|`string`|-|The The tax config ID of the report.|
-|`userId`|`string`|-|**Required** The unique identifier of the Concur user who is the report owner.|
+| Name                            | Type                                | Format                            | Description                                                                                                                                                                                                                                   |
+|---------------------------------|-------------------------------------|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `allocationFormId`              | `string`                            | -                                 | The unique identifier of the allocation form.                                                                                                                                                                                                 |
+| `amountCompanyPaid`             | [`Amount`](#amount-schema)          | -                                 | **Required** The amount paid by the company.                                                                                                                                                                                                  |
+| `amountDueCompany`              | [`Amount`](#amount-schema)          | -                                 | **Required** The amount that the employee owes the company.                                                                                                                                                                                   |
+| `amountDueCompanyCard`          | [`Amount`](#amount-schema)          | -                                 | **Required** The amount that the employee/company owes the corporate card.                                                                                                                                                                    |
+| `amountDueEmployee`             | [`Amount`](#amount-schema)          | -                                 | **Required** The amount that the company owes the employee.                                                                                                                                                                                   |
+| `amountNotApproved`             | [`Amount`](#amount-schema)          | -                                 | **Required** The amount that was not approved for the report.                                                                                                                                                                                 |
+| `analyticsGroupId`              | `string`                            | -                                 | **Required** The unique identifier of the business intelligence hierarchy node.                                                                                                                                                               |
+| `approvalStatus`                | `string`                            | -                                 | **Required** The report’s approval status, in the user’s language.                                                                                                                                                                            |
+| `approvalStatusId`              | `string`                            | -                                 | **Required** The unique identifier of the approval status.                                                                                                                                                                                    |
+| `approvedAmount`                | [`Amount`](#amount-schema)          | -                                 | **Required** The total amount of approved expenses in the report.                                                                                                                                                                             |
+| `businessPurpose`               | `string`                            | -                                 | The text input for the business purpose by the user.                                                                                                                                                                                          |
+| `canRecall`                     | `boolean`                           | `true`/`false`                    | **Required** Whether the report can be recalled by the current user.                                                                                                                                                                          |
+| `canReopen`                     | `boolean`                           | `true`/`false`                    | Whether the report can be reopened after payment.                                                                                                                                                                                             |
+| `cardProgramStatementPeriodId`  | `string`                            | -                                 | The unique identifier of card program statement period on the report.                                                                                                                                                                         |
+| `claimedAmount`                 | [`Amount`](#amount-schema)          | -                                 | **Required** The total amount of all non-personal expenses in the report.                                                                                                                                                                     |
+| `concurAuditStatus`             | `string`                            | -                                 | **Required** The status of audit for the report.                                                                                                                                                                                              |
+| `country`                       | `string`                            | -                                 | The country name associated with the report (localized as per `accept-language` header).                                                                                                                                                      |
+| `countryCode`                   | `string`                            | `ISO 3166-1 alpha-2 country code` | The report country. Maximum characters: 2. Example: `US` - United States                                                                                                                                                                      |
+| `countrySubDivisionCode`        | `string`                            | -                                 | The location country sub division ISO 3166-2 code.                                                                                                                                                                                            |
+| `creationDate`                  | `string`                            | `YYYY-MM-DDTHH:mm:ssZ`            | **Required** The UTC datetime when the user created the report.                                                                                                                                                                               |
+| `currency`                      | `string`                            | -                                 | **Required** The currency name for the report (localized as per `accept-language` header).                                                                                                                                                    |
+| `currencyCode`                  | `string`                            | -                                 | **Required** The 3-letter ISO 4217 currency code for the expense report currency. Examples: `USD` - US dollars; `BRL` - Brazilian real; `CAD` - Canadian dollar; `CHF` - Swiss franc; `EUR` - Euro; `GBO` - Pound sterling; `HKD` - Hong Kong |
+| `customData`                    | [`CustomData`](#custom-data-schema) | -                                 | The details from the `customData` fields. These fields may not have data, depending on the configuration.                                                                                                                                     |
+| `endDate`                       | `string`                            | `YYYY-MM-DD`                      | The end date (ISO-8601) of the report as used for trip-based reporting.                                                                                                                                                                       |
+| `hierarchyNodeId`               | `string`                            | -                                 | **Required** The unique identifier of the group hierarchy node for the report resource.                                                                                                                                                       |
+| `isFinancialIntegrationEnabled` | `boolean`                           | `true`/`false`                    | **Required** Whether the Financial Integration setting has been enabled for this report.                                                                                                                                                      |
+| `isPaperReceiptsReceived`       | `boolean`                           | `true`/`false`                    | **Required** Whether paper receipts have been received for the report.                                                                                                                                                                        |
+| `isReceiptImageAvailable`       | `boolean`                           | `true`/`false`                    | **Required** Whether the receipt image is available at the report level.                                                                                                                                                                      |
+| `isReceiptImageRequired`        | `boolean`                           | `true`/`false`                    | **Required** Whether the receipt image is required at the report level.                                                                                                                                                                       |
+| `isReopened`                    | `boolean`                           | `true`/`false`                    | Whether the report is reopened.                                                                                                                                                                                                               |
+| `ledger`                        | `string`                            | -                                 | **Required** The ledger name to which the report belongs (localized as per `accept-language` header).                                                                                                                                         |
+| `ledgerId`                      | `string`                            | -                                 | **Required** The unique identifier of the ledger.                                                                                                                                                                                             |
+| `links`                         | [`Link`](#link-schema)              | -                                 | Resource links related to this call.                                                                                                                                                                                                          |
+| `name`                          | `string`                            | -                                 | **Required** The expense report name input by the user.                                                                                                                                                                                       |
+| `paymentConfirmedAmount`        | [`Amount`](#amount-schema)          | -                                 | **Required** The amount that was paid on the report.                                                                                                                                                                                          |
+| `paymentStatus`                 | `string`                            | -                                 | **Required** The report's payment status in the user's language.                                                                                                                                                                              |
+| `paymentStatusId`               | `string`                            | -                                 | **Required** The unique identifier of the payment status of the report.                                                                                                                                                                       |
+| `personalAmount`                | [`Amount`](#amount-schema)          | -                                 | **Required** The total amount of expenses marked as personal on the report.                                                                                                                                                                   |
+| `policy`                        | `string`                            | -                                 | **Required** The policy name to which the report adheres (localized as per `accept-language` header).                                                                                                                                         |
+| `policyId`                      | `string`                            | -                                 | **Required** The unique identifier of the policy that applies to this report.                                                                                                                                                                 |
+| `redirectFund`                  | [`RedirectFund`](#redirect-fund)    | -                                 | Funds redirected to IBCP card.                                                                                                                                                                                                                |
+| `reportDate`                    | `string`                            | `YYYY-MM-DD`                      | The date assigned to the report by the user.                                                                                                                                                                                                  |
+| `reportFormId`                  | `string`                            | -                                 | **Required** The unique identifier of the report form.                                                                                                                                                                                        |
+| `reportId`                      | `string`                            | -                                 | **Required** The unique identifier for the report resource.                                                                                                                                                                                   |
+| `reportNumber`                  | `string`                            | -                                 | User friendly unique identifier for the report.                                                                                                                                                                                               |
+| `reportTotal`                   | [`Amount`](#amount-schema)          | -                                 | **Required** The total amount on the report.                                                                                                                                                                                                  |
+| `reportType`                    | `string`                            | -                                 | This value identifies the method used to create the report. Statement refers to company billed statement reports and auto-created refers to reports created by Expense Assistant.                                                             |
+| `reportVersion`                 | `integer`                           | `int32`                           | **Required** The current version of the report.                                                                                                                                                                                               |
+| `startDate`                     | `string`                            | `YYYY-MM-DD`                      | The start date of the report as used for trip-based reporting.                                                                                                                                                                                |
+| `submitDate`                    | `string`                            | `YYYY-MM-DDTHH:mm:ssZ`            | The UTC datetime when the user submitted the report.                                                                                                                                                                                          |
+| `submitterId`                   | `string`                            | -                                 | The unique identifier of the employee who submitted the report.                                                                                                                                                                               |
+| `taxConfigId`                   | `string`                            | -                                 | The The tax config ID of the report.                                                                                                                                                                                                          |
+| `userId`                        | `string`                            | -                                 | **Required** The unique identifier of the Concur user who is the report owner.                                                                                                                                                                |
 
 ### <a name="create-report-schema"></a>NewReport
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`businessPurpose`|`string`|-|The text input for the business purpose by the user.|
-|`comment`|`string`|-|The expense report comment added by the user.|
-|`countryCode`|`string`|-|The location country ISO 3166-1 code.|
-|`countrySubDivisionCode`|`string`|-|The location country sub division ISO 3166-2 code.|
-|`customData`|[`CustomData`](#custom-data-schema)|-|The details from the `customData` fields. These fields may not have data, depending on the configuration.|
-|`endDate`|`string`|`YYYY-MM-DD`|The end date of the report as used for trip-based reporting.|
-|`name`|`string`|-|The expense report name input by the user.|
-|`policyId`|`string`|-|The unique identifier of the policy that applies to this report.|
-|`reportDate`|`string`|`YYYY-MM-DD`|The date assigned to the report by the user.|
-|`startDate`|`string`|`YYYY-MM-DD`|The start date of the report as used for trip-based reporting.|
+| Name                     | Type                                | Format       | Description                                                                                               |
+|--------------------------|-------------------------------------|--------------|-----------------------------------------------------------------------------------------------------------|
+| `businessPurpose`        | `string`                            | -            | The text input for the business purpose by the user.                                                      |
+| `comment`                | `string`                            | -            | The expense report comment added by the user.                                                             |
+| `countryCode`            | `string`                            | -            | The location country ISO 3166-1 code.                                                                     |
+| `countrySubDivisionCode` | `string`                            | -            | The location country sub division ISO 3166-2 code.                                                        |
+| `customData`             | [`CustomData`](#custom-data-schema) | -            | The details from the `customData` fields. These fields may not have data, depending on the configuration. |
+| `endDate`                | `string`                            | `YYYY-MM-DD` | The end date of the report as used for trip-based reporting.                                              |
+| `name`                   | `string`                            | -            | The expense report name input by the user.                                                                |
+| `policyId`               | `string`                            | -            | The unique identifier of the policy that applies to this report.                                          |
+| `reportDate`             | `string`                            | `YYYY-MM-DD` | The date assigned to the report by the user.                                                              |
+| `startDate`              | `string`                            | `YYYY-MM-DD` | The start date of the report as used for trip-based reporting.                                            |
 
 ### <a name="update-report-schema"></a>UpdateReport
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`businessPurpose`|`string`|-|The text input for the business purpose by the user.|
-|`comment`|`string`|-|The expense report comment added by the user.|
-|`country`|`string`|-|The country name associated with the report (localized as per `accept-language` header).|
-|`countryCode`|`string`|-|The location country ISO 3166-1 code.|
-|`countrySubDivisionCode`|`string`|-|The location country sub division ISO 3166-2 code.|
-|`customData`|[`CustomData`](#custom-data-schema)|-|The details from the `customData` fields. These fields may not have data, depending on the configuration.|
-|`endDate`|`string`|`YYYY-MM-DD`|The end date of the report as used for trip-based reporting.|
-|`isCopyDownInherited`|`boolean`|`true`/`false`|If `true`, any change in the report header fields will be copied down to expenses, itemizations and allocations, as per the configuration. Usage of this flag should be deliberate as data corruption could result.|
-|`isPaperReceiptsReceived`|`boolean`|`true`/`false`|Whether paper receipts have been received for the report.|
-|`name`|`string`|-|The expense report name input by the user.|
-|`policy`|`string`|-|The policy name to which the report adheres to.|
-|`policyId`|`string`|-|The unique identifier of the policy that applies to this report.|
-|`redirectFund`|[`RedirectFund`](#redirect-fund-schema)|-|Funds redirected to IBCP card.|
-|`reportDate`|`string`|`YYYY-MM-DD`|The date assigned to the report by the user.|
-|`reportSource`|`string`|-|**Required** The source of the report. Supported values: `EA` - Expense Assistant, `MOB` - Mobile, `OTHER` - Unknown, `SE` - Smart Expense, `TR` - Travel Request, `UI` - Web UI|
-|`startDate`|`string`|`YYYY-MM-DD`|The start date of the report as used for trip-based reporting.|
+| Name                      | Type                                    | Format         | Description                                                                                                                                                                                                         |
+|---------------------------|-----------------------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `businessPurpose`         | `string`                                | -              | The text input for the business purpose by the user.                                                                                                                                                                |
+| `comment`                 | `string`                                | -              | The expense report comment added by the user.                                                                                                                                                                       |
+| `country`                 | `string`                                | -              | The country name associated with the report (localized as per `accept-language` header).                                                                                                                            |
+| `countryCode`             | `string`                                | -              | The location country ISO 3166-1 code.                                                                                                                                                                               |
+| `countrySubDivisionCode`  | `string`                                | -              | The location country sub division ISO 3166-2 code.                                                                                                                                                                  |
+| `customData`              | [`CustomData`](#custom-data-schema)     | -              | The details from the `customData` fields. These fields may not have data, depending on the configuration.                                                                                                           |
+| `endDate`                 | `string`                                | `YYYY-MM-DD`   | The end date of the report as used for trip-based reporting.                                                                                                                                                        |
+| `isCopyDownInherited`     | `boolean`                               | `true`/`false` | If `true`, any change in the report header fields will be copied down to expenses, itemizations and allocations, as per the configuration. Usage of this flag should be deliberate as data corruption could result. |
+| `isPaperReceiptsReceived` | `boolean`                               | `true`/`false` | Whether paper receipts have been received for the report.                                                                                                                                                           |
+| `name`                    | `string`                                | -              | The expense report name input by the user.                                                                                                                                                                          |
+| `policy`                  | `string`                                | -              | The policy name to which the report adheres to.                                                                                                                                                                     |
+| `policyId`                | `string`                                | -              | The unique identifier of the policy that applies to this report.                                                                                                                                                    |
+| `redirectFund`            | [`RedirectFund`](#redirect-fund-schema) | -              | Funds redirected to IBCP card.                                                                                                                                                                                      |
+| `reportDate`              | `string`                                | `YYYY-MM-DD`   | The date assigned to the report by the user.                                                                                                                                                                        |
+| `reportSource`            | `string`                                | -              | **Required** The source of the report. Supported values: `EA` - Expense Assistant, `MOB` - Mobile, `OTHER` - Unknown, `SE` - Smart Expense, `TR` - Travel Request, `UI` - Web UI                                    |
+| `startDate`               | `string`                                | `YYYY-MM-DD`   | The start date of the report as used for trip-based reporting.                                                                                                                                                      |
+
+### <a name="update-submitted-report-schema"></a>Update Submitted Report
+
+| Name                      | Type                                | Format         | Description                                                                                               |
+|---------------------------|-------------------------------------|----------------|-----------------------------------------------------------------------------------------------------------|
+| `businessPurpose`         | `string`                            | -              | The text input for the business purpose by the user.                                                      |
+| `comment`                 | `string`                            | -              | The expense report comment added by the user.                                                             |
+| `customData`              | [`CustomData`](#custom-data-schema) | -              | The details from the `customData` fields. These fields may not have data, depending on the configuration. |
+| `name`                    | `string`                            | -              | The expense report name input by the user.                                                                |
+| `isPaperReceiptsReceived` | `boolean`                           | `true`/`false` | Whether paper receipts have been received for the report.                                                 |
 
 ### <a name="custom-data-schema"></a>CustomData
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|**Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`|
-|`isValid`|`boolean`|`true`/`false`|Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true`|
-|`value`|`string`|-|The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters|
+| Name      | Type      | Format         | Description                                                                                                                                                                                          |
+|-----------|-----------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`      | `string`  | -              | **Required** The unique identifier of the custom field. Examples: `custom1`, `orgUnit1`                                                                                                              |
+| `isValid` | `boolean` | `true`/`false` | Whether the value returned is valid or not. This value is returned for custom fields of all data types and is specifically evaluated for list items to represent the current status. Default: `true` |
+| `value`   | `string`  | -              | The value of the custom field. This field can have values for all the supported data types such as `text`, `integer`, `boolean` and `listItemId`. Maximum length: 48 characters                      |
 
 ### <a name="amount-schema"></a>Amount
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`currencyCode`|`string`|-|**Required** The 3-letter ISO 4217 currency code for the expense report currency, based on the user's assigned reimbursement currency when the report was created. Examples: `USD` - US dollars; `BRL` - Brazilian real; `CAD` - Canadian dollar; `CHF` - Swiss franc; `EUR` - Euro; `GBO` - Pound sterling; `HKD` - Hong Kong dollar; `INR` - Indian rupee; `MXN` - Mexican peso; `NOK` - Norwegian krone; `SEK` - Swedish krona|
-|`value`|`number`|`double`|**Required** The amount in the defined currency.|
+| Name           | Type     | Format   | Description                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|----------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `currencyCode` | `string` | -        | **Required** The 3-letter ISO 4217 currency code for the expense report currency, based on the user's assigned reimbursement currency when the report was created. Examples: `USD` - US dollars; `BRL` - Brazilian real; `CAD` - Canadian dollar; `CHF` - Swiss franc; `EUR` - Euro; `GBO` - Pound sterling; `HKD` - Hong Kong dollar; `INR` - Indian rupee; `MXN` - Mexican peso; `NOK` - Norwegian krone; `SEK` - Swedish krona |
+| `value`        | `number` | `double` | **Required** The amount in the defined currency.                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ### <a name="redirect-fund-schema"></a>RedirectFund
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`amount`|[`Amount`](#amount-schema)|-|**Required** The value of funds redirected to the IBCP card account.|
-|`creditCardId`|`string`|-|**Required** The unique identifier of the IBCP card account to which funds need to be redirected.|
+| Name           | Type                       | Format | Description                                                                                       |
+|----------------|----------------------------|--------|---------------------------------------------------------------------------------------------------|
+| `amount`       | [`Amount`](#amount-schema) | -      | **Required** The value of funds redirected to the IBCP card account.                              |
+| `creditCardId` | `string`                   | -      | **Required** The unique identifier of the IBCP card account to which funds need to be redirected. |
 
 ### <a name="link-schema"></a>Link
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`deprecation`|`string`|-|-|
-|`href`|`string`|-|**Required** The URL of the related `HATEOAS` link that you can use for subsequent calls.|
-|`hreflang`|`string`|-|-|
-|`isTemplated`|`boolean`|`true`/`false`|**Required** Whether the `href` is parameterized.|
-|`media`|`string`|-|-|
-|`method`|`string`|-|**Required** The HTTP method required for the related call.|
-|`rel`|`string`|-|**Required** The link relationship that describes how the `href` relates to the API call.|
-|`title`|`string`|-|-|
-|`type`|`string`|-|-|
+| Name          | Type      | Format         | Description                                                                               |
+|---------------|-----------|----------------|-------------------------------------------------------------------------------------------|
+| `deprecation` | `string`  | -              | -                                                                                         |
+| `href`        | `string`  | -              | **Required** The URL of the related `HATEOAS` link that you can use for subsequent calls. |
+| `hreflang`    | `string`  | -              | -                                                                                         |
+| `isTemplated` | `boolean` | `true`/`false` | **Required** Whether the `href` is parameterized.                                         |
+| `media`       | `string`  | -              | -                                                                                         |
+| `method`      | `string`  | -              | **Required** The HTTP method required for the related call.                               |
+| `rel`         | `string`  | -              | **Required** The link relationship that describes how the `href` relates to the API call. |
+| `title`       | `string`  | -              | -                                                                                         |
+| `type`        | `string`  | -              | -                                                                                         |
 
 ### <a name="error-message-schema"></a>ErrorMessage
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`customResponseData`|`object`|-|The custom parameters related to error.|
-|`errorId`|`string`|-|The unique identifier of the error associated with the response.|
-|`errorMessage`|`string`|-|**Required** The detailed error message.|
-|`httpStatus`|`string`|-|**Required** The http response code and phrase for the response.|
-|`path`|`string`|-|**Required** The URI of the attempted request.|
-|`timestamp`|`string`|`date-time`|**Required** The time when the error was captured.|
-|`validationErrors`|[`ValidationError`](#validation-error-schema)|-|The validation error messages.|
+| Name                 | Type                                          | Format      | Description                                                      |
+|----------------------|-----------------------------------------------|-------------|------------------------------------------------------------------|
+| `customResponseData` | `object`                                      | -           | The custom parameters related to error.                          |
+| `errorId`            | `string`                                      | -           | The unique identifier of the error associated with the response. |
+| `errorMessage`       | `string`                                      | -           | **Required** The detailed error message.                         |
+| `httpStatus`         | `string`                                      | -           | **Required** The http response code and phrase for the response. |
+| `path`               | `string`                                      | -           | **Required** The URI of the attempted request.                   |
+| `timestamp`          | `string`                                      | `date-time` | **Required** The time when the error was captured.               |
+| `validationErrors`   | [`ValidationError`](#validation-error-schema) | -           | The validation error messages.                                   |
 
 ### <a name="validation-errors-schema"></a>ValidationError
 
-|Name|Type|Format|Description|
-|---|---|---|---|
-|`id`|`string`|-|The ID of the validation error.|
-|`message`|`string`|-|The detailed message of the validation error.|
-|`source`|`string`|-|The type of validation which failed.|
+| Name      | Type     | Format | Description                                   |
+|-----------|----------|--------|-----------------------------------------------|
+| `id`      | `string` | -      | The ID of the validation error.               |
+| `message` | `string` | -      | The detailed message of the validation error. |
+| `source`  | `string` | -      | The type of validation which failed.          |
+
+### <a name="employee-schema"></a>Employee
+
+| Name           | Type     | Format | Description                                                                        |
+|----------------|----------|--------|------------------------------------------------------------------------------------|
+| `employeeId`   | `string` | -      | Unique identifier of the employee that can be referenced in external systems.      |
+| `employeeUuid` | `string` | -      | UUID of the employee used to identify the employee within internal concur systems. |


### PR DESCRIPTION
Associated PR:
https://github.com/SAP-docs/preview.developer.concur.com/pull/1283

Changes:
* MANAGER context support properly documented for a variety of endpoints
* `Update submitted report` endpoint had its name, description, and schema updated to better cater to external callers. Concept of 'Short url vs long url' removed from any naming conventions. Description updated to include limitations around when this URL can be used.
* `Get reports to approve`endpoint got a once over with the big change being adding in a proper response schema on top of the example given.
* Comments API updated with the proper employee schema. We do not return `first name`/`last name`/ `middle initial`, we return an `employeeUuid` and `employeeId`