### PR TITLE
fix: [HOTEL-20922] indentation for reshopInfo in hotel rate details request example

### DIFF
--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints-new.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints-new.md
@@ -586,7 +586,7 @@ POST /hotels/ratedetails
   "numGuests": 1,
   "guestCountryCode": "CA",
   "searchSessionToken": "b41168ba-7ee1-4b68-9934-47f5c55337d6",
-    "reshopInfo": {
+  "reshopInfo": {
     "gdsRecordLocator": {
       "gdsName": "SABRE",
       "pcc": "ABC123",


### PR DESCRIPTION
# Overview

Previous [PR](https://github.com/SAP-docs/preview.developer.concur.com/pull/1412) was merged with the incorrect identation, solving with this new one.


# Incorrect spacing
![Screenshot 2025-06-13 at 10 59 38](https://github.com/user-attachments/assets/be9c42ab-c36d-429d-8dc6-5975b955a912)
