### PR TITLE
docs: [HOTEL-23694] added highlightedRateText to direct connect documentation 

### DIFF
--- a/src/api-explorer/v4-0/HotelService.swagger2.json
+++ b/src/api-explorer/v4-0/HotelService.swagger2.json
@@ -2372,6 +2372,10 @@
         "totalPrice": {
           "$ref": "#/definitions/TotalPrice"
         },
+        "highlightedRateText": {
+          "description": "Informational text for highlighted rate",
+          "type": "string"
+        },
         "rateDetailsCallRequired": {
           "description": "Does this rate require a call to rateDetails before booking",
           "example": true,

--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
@@ -274,6 +274,7 @@ POST /hotels/rates
             },
             "prepayRequired": true,
             "refundable": true,
+            "highlightedRateText": "Informational text for highlighted rate",
             "rateDetailsCallRequired" : true,
             "totalPrice": {
               "totalBeforeTax": 170.95,

--- a/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
@@ -253,6 +253,7 @@ Details about the total pricing associated with stay.
 `totalPrice`|[`TotalPrice`](#schematotalprice)|-|**Required** Details about total pricing associated with the stay.|
 `nightlyPrices`|[`NightlyPrice`](#schemanightlyprice)|-|Details about nightly price for a given date range.|
 `cancelPenalties`|[`CancelPenalties`](#schemacancelpenalties)|-|Information about cancellation penalties.|
+`highlightedRateText`|`string`|-|Informational text for highlighted rate|
 `rateDetailsCallRequired`|`boolean`|`true` / `false`|If `true`, this rate requires a call to [`RateDetails`](#rate-details-) before being booked. Default: false|
 
 ## <a id="schemaroomratedetails"></a> RoomRateDetails


### PR DESCRIPTION
Hotel connectors have the requirement to highlight specific rates they want to recommend to their customers. To address this need, we are introducing the `highlightedRateText` field in the RateResponse model for the `/hotels/rates` endpoint. This new field is of type string and is optional.
![swagger](https://github.com/user-attachments/assets/9f863e16-b61c-4539-ac24-bacb592354d1)

![image](https://github.com/user-attachments/assets/902b9de8-9b19-437e-9370-81f5872f9a66)


