### PR TITLE
Adding accepted payments field on hotel search response

### DIFF
--- a/src/api-explorer/v4-0/HotelService.swagger2.json
+++ b/src/api-explorer/v4-0/HotelService.swagger2.json
@@ -1317,6 +1317,9 @@
         },
         "safetyScore": {
            "$ref" : "#/definitions/SafetyScore"
+        },
+        "acceptedPayments": {
+          "$ref": "#/definitions/PaymentCardType"
         }
       },
       "required": [


### PR DESCRIPTION
Adding a new field on hotel SearchResponse to accept `acceptedPayments` types from our suppliers