### PR TITLE
docs: [HOTEL-25800] add GDS name and PCC fields to requestorInfo

### DIFF
--- a/src/api-explorer/v4-0/HotelService.swagger2.json
+++ b/src/api-explorer/v4-0/HotelService.swagger2.json
@@ -2023,6 +2023,20 @@
           "description": "UUID that identifies the traveler within Concur",
           "example": "123e4567-e89b-12d3-a456-426614174000",
           "type": "string"
+        },
+        "gdsName": {
+          "description": "Name of the GDS (Global Distribution System) to be used for this booking (active or passive segment). Supported values: SABRE, AMADEUS, TRAVELPORT",
+          "type": "string",
+          "enum": [
+            "SABRE",
+            "AMADEUS",
+            "TRAVELPORT"
+          ]
+        },
+        "pcc": {
+          "description": "Pseudo City Code or Office ID (OID) for the GDS account to be used for this booking (active or passive segment).",
+          "type": "string",
+          "example": "ABC123"
         }
       },
       "required": [

--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
@@ -30,12 +30,14 @@ POST /hotels/search
 
 ```json
 {
-  "requestorInfo": {
-    "posRequestorId": "abc1234",
-    "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
-    "loginId": "abc@concur.com",
-    "bookingForSelf": true
-  },
+ "requestorInfo": {
+  "posRequestorId": "abc1234",
+  "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
+  "loginId": "abc@concur.com",
+  "bookingForSelf": true,
+  "pcc": "ABC123",
+  "gdsName": "SABRE"
+},
   "numGuests": 1,
   "guestCountryCode": "CA",
   "locationSearch": {
@@ -184,12 +186,14 @@ POST /hotels/rates
 
 ```json
 {
-  "requestorInfo": {
-    "posRequestorId": "abc1234",
-    "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
-    "loginId": "abc@concur.com",
-    "bookingForSelf": true
-  },
+ "requestorInfo": {
+  "posRequestorId": "abc1234",
+  "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
+  "loginId": "abc@concur.com",
+  "bookingForSelf": true,
+  "pcc": "ABC123",
+  "gdsName": "SABRE"
+},
   "hotelPropertyRefs": [
     {
       "chainCode": "HH",
@@ -385,12 +389,14 @@ POST /hotels/ratedetails
 
 ```json
 {
-  "requestorInfo": {
-    "posRequestorId": "abc1234",
-    "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
-    "loginId": "abc@concur.com",
-    "bookingForSelf": true
-  },
+ "requestorInfo": {
+  "posRequestorId": "abc1234",
+  "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
+  "loginId": "abc@concur.com",
+  "bookingForSelf": true,
+  "pcc": "ABC123",
+  "gdsName": "SABRE"
+},
   "hotelPropertyRef": {
     "chainCode": "HH",
     "propertyCode": "HH498949"
@@ -563,12 +569,14 @@ POST /hotels/ratedetails
 
 ```json
 {
-  "requestorInfo": {
-    "posRequestorId": "abc1234",
-    "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
-    "loginId": "abc@concur.com",
-    "bookingForSelf": true
-  },
+ "requestorInfo": {
+  "posRequestorId": "abc1234",
+  "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
+  "loginId": "abc@concur.com",
+  "bookingForSelf": true,
+  "pcc": "ABC123",
+  "gdsName": "SABRE"
+},
   "hotelPropertyRef": {
     "chainCode": "HH",
     "propertyCode": "HH498949"
@@ -758,12 +766,14 @@ POST /hotels/details
 
 ```json
 {
-  "requestorInfo": {
-    "posRequestorId": "abc1234",
-    "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
-    "loginId": "abc@concur.com",
-    "bookingForSelf": true
-  },
+ "requestorInfo": {
+  "posRequestorId": "abc1234",
+  "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
+  "loginId": "abc@concur.com",
+  "bookingForSelf": true,
+  "pcc": "ABC123",
+  "gdsName": "SABRE"
+},
   "hotelCodes": [
     {
       "chainCode": "HH",
@@ -842,12 +852,14 @@ POST /hotels/reservation
     "chainCode": "HH",
     "propertyCode": "HH498949"
   },
-  "requestorInfo": {
-    "posRequestorId": "abc1234",
-    "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
-    "loginId": "abc@concur.com",
-    "bookingForSelf": true
-  },
+ "requestorInfo": {
+  "posRequestorId": "abc1234",
+  "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
+  "loginId": "abc@concur.com",
+  "bookingForSelf": true,
+  "pcc": "ABC123",
+  "gdsName": "SABRE"
+},
   "ratePlanId": "44SM3FAsfvgcZs9ehGlNOQ",
   "guests": [
     {
@@ -1168,12 +1180,14 @@ POST /hotels/reservation/read
 
 ```json
 {
-  "requestorInfo": {
-    "posRequestorId": "abc1234",
-    "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
-    "loginId": "abc@concur.com",
-    "bookingForSelf": true
-  },
+ "requestorInfo": {
+  "posRequestorId": "abc1234",
+  "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
+  "loginId": "abc@concur.com",
+  "bookingForSelf": true,
+  "pcc": "ABC123",
+  "gdsName": "SABRE"
+},
   "confirmationCodes": [
     {
       "codeType": "SUPPLIER_CONFIRMATION",
@@ -1682,12 +1696,14 @@ POST /hotels/reservation/cancel
 
 ```json
 {
-  "requestorInfo": {
-    "posRequestorId": "abc1234",
-    "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
-    "loginId": "abc@concur.com",
-    "bookingForSelf": true
-  },
+ "requestorInfo": {
+  "posRequestorId": "abc1234",
+  "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
+  "loginId": "abc@concur.com",
+  "bookingForSelf": true,
+  "pcc": "ABC123",
+  "gdsName": "SABRE"
+},
   "confirmationCodes": [
     {
       "codeType": "SUPPLIER_CONFIRMATION",

--- a/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
@@ -337,6 +337,8 @@ Information about Point of Sale (POS), traveler, and user associated with the re
 `travelerUuid`|`string`|-|**Required** UUID that identifies the traveler within SAP Concur systems.|
 `loginId`|`string`|-|Login ID of traveler within SAP Concur systems, if available.|
 `bookingForSelf`|`boolean`|`true` / `false`|If `true`, the person logged in is making a booking for themselves.|
+`gdsName`|`string`|-|Name of the GDS (Global Distribution System) to be used for this booking (active or passive segment). Supported values: `SABRE`, `AMADEUS`, `TRAVELPORT`|
+`pcc`|`string`|-|Pseudo City Code or Office ID (OID) for the GDS account to be used for this booking (active or passive segment).|
 
 ## <a id="schemaradius"></a> Radius
 


### PR DESCRIPTION
## Overview:

Add `gdsName` and `pcc` attributes to requestorInfo property.
Both are optional since they are filled only when singlePNR is enabled.

## Evidences:

### On Markdown Preview
<img width="1049" height="479" alt="Screenshot 2025-09-23 at 15 02 12" src="https://github.com/user-attachments/assets/159d92a6-6972-4324-95fe-cbe877e2e735" />

### On Swagger Preview
<img width="1049" height="733" alt="Screenshot 2025-09-23 at 15 02 21" src="https://github.com/user-attachments/assets/9ef072ac-8ecb-4480-839e-5a9c59678275" />

<img width="1472" height="1031" alt="Screenshot 2025-09-23 at 15 03 08" src="https://github.com/user-attachments/assets/59d7c6ca-d0ed-4b19-b643-2546403b2f24" />

