### PR TITLE
Removes BOM from release notes API files

### DIFF
--- a/src/tools-support/release-notes/api/2025-01-09.md
+++ b/src/tools-support/release-notes/api/2025-01-09.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, January 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-02-06.md
+++ b/src/tools-support/release-notes/api/2025-02-06.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, February 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-03-06.md
+++ b/src/tools-support/release-notes/api/2025-03-06.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, March 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-04-03.md
+++ b/src/tools-support/release-notes/api/2025-04-03.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, April 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-05-05.md
+++ b/src/tools-support/release-notes/api/2025-05-05.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, May 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-06-04.md
+++ b/src/tools-support/release-notes/api/2025-06-04.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, June 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-07-10.md
+++ b/src/tools-support/release-notes/api/2025-07-10.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, July 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-08-07.md
+++ b/src/tools-support/release-notes/api/2025-08-07.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, August 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-09-04.md
+++ b/src/tools-support/release-notes/api/2025-09-04.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, September 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-10-02.md
+++ b/src/tools-support/release-notes/api/2025-10-02.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, October 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-11-11.md
+++ b/src/tools-support/release-notes/api/2025-11-11.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, November 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2025-12-04.md
+++ b/src/tools-support/release-notes/api/2025-12-04.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, December 2025
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2026-01-12.md
+++ b/src/tools-support/release-notes/api/2026-01-12.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, January 2026
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2026-02-04.md
+++ b/src/tools-support/release-notes/api/2026-02-04.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, February 2026
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2026-03-03.md
+++ b/src/tools-support/release-notes/api/2026-03-03.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, March 2026
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/2026-04-06.md
+++ b/src/tools-support/release-notes/api/2026-04-06.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, April 2026
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2021-09-17.md
+++ b/src/tools-support/release-notes/api/archive/2021-09-17.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, September 2021
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2021-10-15.md
+++ b/src/tools-support/release-notes/api/archive/2021-10-15.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, October 2021
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2021-11-10.md
+++ b/src/tools-support/release-notes/api/archive/2021-11-10.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, November 2021
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2021-12-09.md
+++ b/src/tools-support/release-notes/api/archive/2021-12-09.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, December 2021
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-01-13.md
+++ b/src/tools-support/release-notes/api/archive/2022-01-13.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, January 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-02-17.md
+++ b/src/tools-support/release-notes/api/archive/2022-02-17.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, February 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-03-17.md
+++ b/src/tools-support/release-notes/api/archive/2022-03-17.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, March 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-04-08.md
+++ b/src/tools-support/release-notes/api/archive/2022-04-08.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, April 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-05-19.md
+++ b/src/tools-support/release-notes/api/archive/2022-05-19.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, May 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-06-24.md
+++ b/src/tools-support/release-notes/api/archive/2022-06-24.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, June 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-07-08.md
+++ b/src/tools-support/release-notes/api/archive/2022-07-08.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, July 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-08-12.md
+++ b/src/tools-support/release-notes/api/archive/2022-08-12.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, August 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-09-16.md
+++ b/src/tools-support/release-notes/api/archive/2022-09-16.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, September 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-10-14.md
+++ b/src/tools-support/release-notes/api/archive/2022-10-14.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, October 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-11-10.md
+++ b/src/tools-support/release-notes/api/archive/2022-11-10.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, November 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2022-12-02.md
+++ b/src/tools-support/release-notes/api/archive/2022-12-02.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, December 2022
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-01-05.md
+++ b/src/tools-support/release-notes/api/archive/2023-01-05.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, January 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-02-03.md
+++ b/src/tools-support/release-notes/api/archive/2023-02-03.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, February 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-03-10.md
+++ b/src/tools-support/release-notes/api/archive/2023-03-10.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, March 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-04-07.md
+++ b/src/tools-support/release-notes/api/archive/2023-04-07.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, April 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-05-04.md
+++ b/src/tools-support/release-notes/api/archive/2023-05-04.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, May 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-06-02.md
+++ b/src/tools-support/release-notes/api/archive/2023-06-02.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, June 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-07-12.md
+++ b/src/tools-support/release-notes/api/archive/2023-07-12.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, July 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-08-10.md
+++ b/src/tools-support/release-notes/api/archive/2023-08-10.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, August 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-09-07.md
+++ b/src/tools-support/release-notes/api/archive/2023-09-07.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, September 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-10-12.md
+++ b/src/tools-support/release-notes/api/archive/2023-10-12.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, October 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-11-02.md
+++ b/src/tools-support/release-notes/api/archive/2023-11-02.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, November 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2023-12-14.md
+++ b/src/tools-support/release-notes/api/archive/2023-12-14.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, December 2023
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-01-11.md
+++ b/src/tools-support/release-notes/api/archive/2024-01-11.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, January 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-02-08.md
+++ b/src/tools-support/release-notes/api/archive/2024-02-08.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, February 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-03-14.md
+++ b/src/tools-support/release-notes/api/archive/2024-03-14.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, March 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-04-04.md
+++ b/src/tools-support/release-notes/api/archive/2024-04-04.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, April 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-05-09.md
+++ b/src/tools-support/release-notes/api/archive/2024-05-09.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, May 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-06-06.md
+++ b/src/tools-support/release-notes/api/archive/2024-06-06.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, June 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-07-10.md
+++ b/src/tools-support/release-notes/api/archive/2024-07-10.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, July 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-08-08.md
+++ b/src/tools-support/release-notes/api/archive/2024-08-08.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, August 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-09-12.md
+++ b/src/tools-support/release-notes/api/archive/2024-09-12.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, September 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-10-03.md
+++ b/src/tools-support/release-notes/api/archive/2024-10-03.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, October 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-11-07.md
+++ b/src/tools-support/release-notes/api/archive/2024-11-07.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, November 2024
 layout: reference
 ---

--- a/src/tools-support/release-notes/api/archive/2024-12-05.md
+++ b/src/tools-support/release-notes/api/archive/2024-12-05.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: SAP Concur Developer Center - API Release Notes, December 2024
 layout: reference
 ---


### PR DESCRIPTION
## Summary

- Removes BOM (`\xEF\xBB\xBF`) from 56 files in `src/tools-support/release-notes/api/`
- BOM was accidentally introduced in commit `807319d70` ("fixes broken links") and was preventing Jekyll from parsing front matter, causing 404s on all Developer Platform Release Notes links

## Test plan

- [ ] Verify that links under "Developer Platform Release Notes" on https://preview.developer.concur.com/tools-support/release-notes/index.html no longer return 404