### PR TITLE
Adds charset utf-8 to .editorconfig to prevent BOM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,6 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+charset = utf-8
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Adds `charset = utf-8` to `.editorconfig` to prevent editors from saving files with BOM (Byte Order Mark), which breaks Jekyll front matter parsing and causes 404s.