### PR TITLE
docs: add prepayment details attribute

### DIFF
--- a/src/api-explorer/v4-0/HotelService.swagger2.json
+++ b/src/api-explorer/v4-0/HotelService.swagger2.json
@@ -984,6 +984,11 @@
           "description": "Whether or not this tax/fee is included in totalAmountAfterTax amount.",
           "example": true,
           "type": "boolean"
+        },
+        "isPayableAtProperty": {
+          "description": "Whether or not this tax/fee is payable at the property.",
+          "example": false,
+          "type": "boolean"
         }
       },
       "required": [
@@ -1815,6 +1820,33 @@
       ],
       "type": "object"
     },
+    "RatePrepaymentDetails": {
+      "properties": {
+         "paymentDate": {
+          "description": "Scheduled payment date",
+          "example": "2021-10-20",
+          "format": "date",
+          "type": "string"
+        },
+        "paymentDeadline": {
+          "description": "Deadline date for successful payment",
+          "example": "2021-10-20",
+          "format": "yyyy-MM-dd'T'HH:mm:ss",
+          "type": "string"
+        },
+        "termsAndConditionsUrl": {
+          "description": "URL for the terms and conditions of the rate provided by supplier",
+          "example": "https://terms-and-condition-example-url",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paymentDate",
+        "paymentDeadline",
+        "termsAndConditionsUrl"
+      ],
+      "type": "object"
+    },
     "RateDetailsCriteria": {
       "properties": {
         "checkin": {
@@ -2429,6 +2461,9 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "prepaymentDetails": {
+          "$ref": "#/definitions/RatePrepaymentDetails"
         },
         "ratePlanId": {
           "example": "44SM3FAsfvgcZs9ehGlNOQ",

--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
@@ -286,6 +286,11 @@ POST /hotels/rates
               }
             },
             "prepayRequired": true,
+            "prepaymentDetails": {
+              "paymentDate": "2026-05-10",
+              "paymentDeadline": "2026-05-09T23:59:59Z",
+              "termsAndConditionsUrl": "https://terms-and-condition-example-url"
+            },
             "refundable": true,
             "highlightedRateText": "Informational text for highlighted rate",
             "rateDetailsCallRequired" : true,
@@ -296,12 +301,14 @@ POST /hotels/rates
                 {
                   "amount": 5,
                   "fttCode": 1,
-                  "inclusive": true
+                  "inclusive": true,
+                  "isPayableAtProperty": false
                 },
                 {
                   "amount": 5,
                   "fttCode": 2,
-                  "inclusive": true
+                  "inclusive": true,
+                  "isPayableAtProperty": false
                 }
               ],
               "fees": 10,
@@ -309,12 +316,14 @@ POST /hotels/rates
                 {
                   "amount": 5,
                   "fttCode": 5,
-                  "inclusive": true
+                  "inclusive": true,
+                  "isPayableAtProperty": false
                 },
                 {
                   "amount": 5,
                   "fttCode": 6,
-                  "inclusive": true
+                  "inclusive": true,
+                  "isPayableAtProperty": false
                 }
               ],              
               "totalAfterTax": 190.95,
@@ -465,6 +474,11 @@ POST /hotels/ratedetails
         }
       },
       "prepayRequired": true,
+      "prepaymentDetails": {
+        "paymentDate": "2026-05-10",
+        "paymentDeadline": "2026-05-09T23:59:59Z",
+        "termsAndConditionsUrl": "https://terms-and-condition-example-url"
+      },
       "refundable": true,
       "totalPrice": {
         "totalBeforeTax": 170.95,
@@ -474,24 +488,28 @@ POST /hotels/ratedetails
             {
               "amount": 5,
               "fttCode": 1,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             },
             {
               "amount": 5,
               "fttCode": 2,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
         ],
         "feesBreakdown": [
             {
               "amount": 5,
               "fttCode": 5,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             },
             {
               "amount": 5,
               "fttCode": 6,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
         ],              
         "totalAfterTax": 190.95,
@@ -507,7 +525,8 @@ POST /hotels/ratedetails
               {
                 "amount": 8.05,
                 "fttCode": 15,
-                "inclusive": true
+                "inclusive": true,
+                "isPayableAtProperty": false
               }
             ]
           },
@@ -517,7 +536,8 @@ POST /hotels/ratedetails
               {
                 "amount": 8.05,
                 "fttCode": 15,
-                "inclusive": true
+                "inclusive": true,
+                "isPayableAtProperty": false
               }
             ]
           },
@@ -662,6 +682,11 @@ POST /hotels/ratedetails
         }
       },
       "prepayRequired": true,
+      "prepaymentDetails": {
+        "paymentDate": "2026-05-10",
+        "paymentDeadline": "2026-05-09T23:59:59Z",
+        "termsAndConditionsUrl": "https://terms-and-condition-example-url"
+      },
       "refundable": true,
       "totalPrice": {
         "totalBeforeTax": 170.95,
@@ -671,24 +696,28 @@ POST /hotels/ratedetails
             {
               "amount": 5,
               "fttCode": 1,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             },
             {
               "amount": 5,
               "fttCode": 2,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
         ],
         "feesBreakdown": [
             {
               "amount": 5,
               "fttCode": 5,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             },
             {
               "amount": 5,
               "fttCode": 6,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
         ],              
         "totalAfterTax": 190.95,
@@ -704,7 +733,8 @@ POST /hotels/ratedetails
               {
                 "amount": 8.05,
                 "fttCode": 15,
-                "inclusive": true
+                "inclusive": true,
+                "isPayableAtProperty": false
               }
             ]
           },
@@ -714,7 +744,8 @@ POST /hotels/ratedetails
               {
                 "amount": 8.05,
                 "fttCode": 15,
-                "inclusive": true
+                "inclusive": true,
+                "isPayableAtProperty": false
               }
             ]
           },
@@ -1044,6 +1075,11 @@ POST /hotels/reservation
       }
     },
     "prepayRequired": true,
+    "prepaymentDetails": {
+      "paymentDate": "2026-05-10",
+      "paymentDeadline": "2026-05-09T23:59:59Z",
+      "termsAndConditionsUrl": "https://terms-and-condition-example-url"
+    },
     "refundable": true,
     "totalPrice": {
       "totalBeforeTax": 170.95,
@@ -1053,24 +1089,28 @@ POST /hotels/reservation
           {
             "amount": 5,
             "fttCode": 1,
-            "inclusive": true
+            "inclusive": true,
+            "isPayableAtProperty": false
           },
           {
             "amount": 5,
             "fttCode": 2,
-            "inclusive": true
+            "inclusive": true,
+            "isPayableAtProperty": false
           }
       ],
       "feesBreakdown": [
           {
             "amount": 5,
             "fttCode": 5,
-            "inclusive": false
+            "inclusive": false,
+            "isPayableAtProperty": false
           },
           {
             "amount": 5,
             "fttCode": 6,
-            "inclusive": false
+            "inclusive": false,
+            "isPayableAtProperty": false
           }
       ],              
       "totalAfterTax": 190.95,
@@ -1086,7 +1126,8 @@ POST /hotels/reservation
             {
               "amount": 8.05,
               "fttCode": 15,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
           ]
         },
@@ -1096,7 +1137,8 @@ POST /hotels/reservation
             {
               "amount": 8.05,
               "fttCode": 15,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
           ]
         },
@@ -1286,6 +1328,11 @@ POST /hotels/reservation/read
       }
     },
     "prepayRequired": true,
+    "prepaymentDetails": {
+      "paymentDate": "2026-05-10",
+      "paymentDeadline": "2026-05-09T23:59:59Z",
+      "termsAndConditionsUrl": "https://terms-and-condition-example-url"
+    },
     "refundable": true,
     "totalPrice": {
       "totalBeforeTax": 170.95,
@@ -1303,7 +1350,8 @@ POST /hotels/reservation/read
             {
               "amount": 8.05,
               "fttCode": 15,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
           ]
         },
@@ -1313,7 +1361,8 @@ POST /hotels/reservation/read
             {
               "amount": 8.05,
               "fttCode": 15,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
           ]
         },
@@ -1587,6 +1636,11 @@ POST /hotels/reservation/modify
       }
     },
     "prepayRequired": true,
+    "prepaymentDetails": {
+      "paymentDate": "2026-05-10",
+      "paymentDeadline": "2026-05-09T23:59:59Z",
+      "termsAndConditionsUrl": "https://terms-and-condition-example-url"
+    },
     "refundable": true,
     "totalPrice": {
       "totalBeforeTax": 170.95,
@@ -1604,7 +1658,8 @@ POST /hotels/reservation/modify
             {
               "amount": 8.05,
               "fttCode": 15,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
           ]
         },
@@ -1614,7 +1669,8 @@ POST /hotels/reservation/modify
             {
               "amount": 8.05,
               "fttCode": 15,
-              "inclusive": true
+              "inclusive": true,
+              "isPayableAtProperty": false
             }
           ]
         },

--- a/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
@@ -262,12 +262,21 @@ Details about the total pricing associated with stay.
 » `cvvRequired`|`boolean`|`true` / `false`||
 » `amountPercent`|[`AmountPercent`](#schemaamountpercent)|-||
 `prepayRequired`|`boolean`|`true` / `false`|If `true`, prepayment is required for booking this rate.|
+» `prepaymentDetails`|[`RatePrepaymentDetails`](#schemarateprepaymentdetails)|-||
 `refundable`|`boolean`|`true` / `false`|If `true`, this rate is refundable (based on all cancel penalties).|
 `totalPrice`|[`TotalPrice`](#schematotalprice)|-|**Required** Details about total pricing associated with the stay.|
 `nightlyPrices`|[`NightlyPrice`](#schemanightlyprice)|-|Details about nightly price for a given date range.|
 `cancelPenalties`|[`CancelPenalties`](#schemacancelpenalties)|-|Information about cancellation penalties.|
 `highlightedRateText`|`string`|-|Informational text for highlighted rate|
 `rateDetailsCallRequired`|`boolean`|`true` / `false`|If `true`, this rate requires a call to [`RateDetails`](#rate-details-) before being booked. Default: false|
+
+## <a id="schemarateprepaymentdetails"></a> RatePrepaymentDetails
+
+|Name|Type|Format|Description|
+|---|---|---|---|
+`paymentDate`|`string`|`date`|**Required** Scheduled payment date.|
+`paymentDeadline`|`string`|`yyyy-MM-dd'T'HH:mm:ss`|**Required** Deadline date for successful payment.|
+`termsAndConditionsUrl`|`string`|-|**Required** URL for the terms and conditions of the rate provided by supplier.|
 
 ## <a id="schemaroomratedetails"></a> RoomRateDetails
 
@@ -284,6 +293,7 @@ Details about the total pricing associated with stay.
 » `cvvRequired`|`boolean`|`true` / `false`||
 » `amountPercent`|[`AmountPercent`](#schemaamountpercent)|-||
 `prepayRequired`|`boolean`|`true` / `false`|If `true`, prepayment is required for booking this rate.|
+» `prepaymentDetails`|[`RatePrepaymentDetails`](#schemarateprepaymentdetails)|-||
 `refundable`|`boolean`|`true` / `false`|If `true`, this rate is refundable (based on all cancel penalties).|
 `totalPrice`|[`TotalPrice`](#schematotalprice)|-|**Required** Details about total pricing associated with the stay.|
 `nightlyPrices`|[`NightlyPrice`](#schemanightlyprice)|-| Details about nightly price for a given date range.|
@@ -600,6 +610,7 @@ Representation of nightly fees associated with a rate for given dates along with
 `amount`|`number`|-|**Required** |
 `fttCode`|`integer`|`int32`|**Required** Code based on [OTA's Fee Tax Type (FTT) list](https://www.opentraveldevelopersnetwork.com/code-list).|
 `inclusive`|`boolean`|`true` / `false`|**Required** If `true`, this tax/fee is included in `totalAmountAfterTax` amount.|
+`isPayableAtProperty`|`boolean`|`true` / `false`|If `true`, this tax/fee is payable at the property.|
 
 ## <a id="schemasustainabilityaward"></a> SustainabilityAward
 


### PR DESCRIPTION
## Summary

Added support for enhanced prepayment information in the Hotel Service v4 API by introducing the RatePrepaymentDetails schema and the isPayableAtProperty field for taxes and fees.

## Changes

- New Schema: RatePrepaymentDetails
    - paymentDate - Scheduled payment date
    - paymentDeadline - Deadline for successful payment                                                                                                                                                              
    - termsAndConditionsUrl - Link to supplier's terms and conditions                                                                                                                                                
- New Field: isPayableAtProperty - Added to tax and fee breakdowns to indicate whether charges are collected at the property or during booking

## Files Modified 
- **src/api-explorer/v4-0/HotelService.swagger2.json** - Updated OpenAPI specification with new schemas and fields                                                                                                     - **src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md** - Updated all endpoint examples (rates, ratedetails, reservation endpoints)
- **src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown** - Added schema documentation for new fields

## Validation

<img width="1168" height="928" alt="image" src="https://github.com/user-attachments/assets/d46343cc-b402-445a-be8d-b78016beecc3" />

<img width="1046" height="296" alt="image" src="https://github.com/user-attachments/assets/57f1fc85-ffed-423b-a4f9-8e0b01e11218" />
