### PR TITLE
feat: [HOTEL-45255] add middle name to guest schema

### DIFF
--- a/src/api-explorer/v4-0/HotelService.swagger2.json
+++ b/src/api-explorer/v4-0/HotelService.swagger2.json
@@ -1064,6 +1064,11 @@
           "example": "Blake",
           "type": "string"
         },
+        "middleName": {
+          "description": "Middle name of the guest.",
+          "example": "Jordan",
+          "type": "string"
+        },
         "lastname": {
           "example": "Smith",
           "type": "string"

--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
@@ -913,6 +913,7 @@ POST /hotels/reservation
   "guests": [
     {
       "firstname": "Blake",
+      "middleName": "Jordan",
       "lastname": "Smith",
       "address": {
         "addressLines": [
@@ -1470,6 +1471,7 @@ POST /hotels/reservation/modify
     "guests": [
       {
         "firstname": "Blake",
+        "middleName": "Jordan",
         "lastname": "Smith",
         "address": {
           "addressLines": [

--- a/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
@@ -458,6 +458,7 @@ For details on usage of confirmation codes, please refer to [Confirmation Codes]
 |Name|Type|Format|Description|
 |---|---|---|---|
 `firstname`|`string`|-|**Required** |
+`middleName`|`string`|-|Middle name of the guest.|
 `lastname`|`string`|-|**Required** |
 `address`|[`Address`](#schemaaddress)|-|-
 `companyName`|`string`|-||


### PR DESCRIPTION
Add the `middleName` field to the Guest schema in the Developer Portal, reflecting the new field introduced in the reservation request.