### PR TITLE
docs: include custom fields on rate / ratedetails

### DIFF
--- a/src/api-explorer/v4-0/HotelService.swagger2.json
+++ b/src/api-explorer/v4-0/HotelService.swagger2.json
@@ -1895,6 +1895,13 @@
         },
         "reshopInfo": {
           "$ref": "#/definitions/ReshopInfo"
+        },
+        "customFields": {
+          "description": "Custom fields supported by the vendor (e.g. CostCenter)",
+          "items": {
+            "$ref": "#/definitions/CustomField"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -1980,6 +1987,13 @@
         "accessViaMobile": {
           "description": "Indicates if the request is coming from mobile device",
           "type": "boolean"
+        },
+        "customFields": {
+          "description": "Custom fields supported by the vendor (e.g. CostCenter)",
+          "items": {
+            "$ref": "#/definitions/CustomField"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
@@ -219,7 +219,13 @@ POST /hotels/rates
   ],
   "numGuests": 1,
   "guestCountryCode": "CA",
-  "searchSessionToken": "b41168ba-7ee1-4b68-9934-47f5c55337d6"
+  "searchSessionToken": "b41168ba-7ee1-4b68-9934-47f5c55337d6",
+  "customFields": [
+    {
+      "name": "OrgUnit",
+      "value": "Travel Agents"
+    }
+  ]
 }
 ```
 
@@ -431,7 +437,13 @@ POST /hotels/ratedetails
   ],
   "numGuests": 1,
   "guestCountryCode": "CA",
-  "searchSessionToken": "b41168ba-7ee1-4b68-9934-47f5c55337d6"
+  "searchSessionToken": "b41168ba-7ee1-4b68-9934-47f5c55337d6",
+  "customFields": [
+    {
+      "name": "OrgUnit",
+      "value": "Travel Agents"
+    }
+  ]
 }
 ```
 

--- a/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
@@ -47,6 +47,7 @@ Reference to location details for search.
 `guestCountryCode`|`string`|`ISO ALPHA-2`|Two-character ISO code for country.|
 `searchSessionToken`|[`SearchSessionToken`](#schemasearchsessiontoken)|-|Session token to be generated and provided by server on initial search call that can be referenced back for future calls on the same session.|
 `accessViaMobile`|`boolean`|`true` \ `false`| Indicates if the request is coming from mobile device.|
+`customFields`|[`CustomField`](#schemacustomfield)|-|Custom fields supported by the vendor. Example: `CostCenter`|
 
 ## <a id="schemaratedetailscritera"></a> RateDetailsCriteria
 
@@ -63,6 +64,7 @@ Reference to location details for search.
 `searchSessionToken`|[`SearchSessionToken`](#schemasearchsessiontoken)|-|Session token to be generated and provided by server on initial search call that can be referenced back for future calls on the same session.|
 `reshopInfo`|[`ReshopInfo`](#schemareshopinfo)|-|Information related to reshopping, only available during modify (and not shopping) flow|
 `accessViaMobile`|`boolean`|`true` \ `false`| Indicates if the request is coming from mobile device.|
+`customFields`|[`CustomField`](#schemacustomfield)|-|Custom fields supported by the vendor. Example: `CostCenter`|
 
 ## <a id="schemahoteldetailscriteria"></a> HotelDetailsCriteria
 


### PR DESCRIPTION
## Changes Made:

This commit adds support for customFields in the Hotel Service v4 API documentation across both the /hotels/rates and /hotels/ratedetails endpoints.

## Files Modified:
1. src/api-explorer/v4-0/HotelService.swagger2.json - Updated API schema definitions
2. src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md - Added example request payloads
3. src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown - Updated schema documentation