### PR TITLE
Adds July 2026 to left navigation and release notes index

### DIFF
--- a/src/_data/sidebars/tools-support.yml
+++ b/src/_data/sidebars/tools-support.yml
@@ -5,6 +5,8 @@
 - title: Developer Platform Release Notes
   url: ''
   children:
+      - title: July 2026
+        url: /tools-support/release-notes/api/2026-07-01.html
       - title: June 2026
         url: /tools-support/release-notes/api/2026-06-03.html
       - title: May 2026

--- a/src/tools-support/release-notes/index.markdown
+++ b/src/tools-support/release-notes/index.markdown
@@ -6,6 +6,7 @@ layout: reference
 
 ## Developer Platform Release Notes
 
+* [July 2026](./api/2026-07-01.html)
 * [June 2026](./api/2026-06-03.html)
 * [May 2026](./api/2026-05-04.html)
 * [April 2026](./api/2026-04-06.html)


### PR DESCRIPTION
## Summary
- Adds July 2026 entry to the Developer Platform Release Notes index page
- Adds July 2026 entry to the left navigation sidebar (tools-support.yml)

## Test plan
- [ ] Verify July 2026 appears at the top of the Developer Platform Release Notes list on the index page
- [ ] Verify July 2026 appears at the top of the left navigation sidebar
- [ ] Verify link resolves to `/tools-support/release-notes/api/2026-07-01.html`