### PR TITLE
Updates July 2026 RN: Decommission of Launch External URL V1

### DIFF
--- a/src/tools-support/release-notes/api/2026-07-01.md
+++ b/src/tools-support/release-notes/api/2026-07-01.md
@@ -19,7 +19,7 @@ Effective Date: August 5, 2026
 
 As previously announced, the Concur Request APIs v1.0, v3.0, and v3.1 have been decommissioned. These versions will be retired and no longer accessible as of August 5, 2026. Customers currently using these versions must migrate to the successor API, Request API V4, to ensure uninterrupted functionality. Please reach out to your Concur representative for more information.
 
-### Decommissioning of Launch External URL V1
+### Updated: Decommissioning of Launch External URL V1
  
 Effective Date: June 23, 2026
  
@@ -45,6 +45,7 @@ APIs are being deprecated or decommissioned in accordance with the [SAP Concur A
 
 Date|API|Details
 ---|---|---
+[06/2026](/tools-support/release-notes/api/2026-06-03.html)|Decommission of Launch External URL V1|Effective June 23, 2026, the Launch External URL V1 callout API was decommissioned. Customers must migrate to Launch External URL V4, which provides full functional equivalence with no known gaps.
 [06/2026](/tools-support/release-notes/api/2026-06-03.html)|Deprecation of Company Cards Transactions v1|Effective June 8, 2026, the Company Cards Transactions v1 API was deprecated. This has been replaced by Cards v4 API. Decommission will follow.
 [10/2025](/tools-support/release-notes/api/2025-10-02.html)|Deprecation of Locations v3|Effective October 10, 2025, the Locations v3 API will be deprecated. This has been replaced by Localities v5. Decommission will follow.
 [07/2025](/tools-support/release-notes/api/2025-07-10.html)|Deprecation of Expense Group Configurations v3|Effective June 26, 2025, the Expense Group Configurations v3 API was deprecated. This has been replaced by the Expense Configuration v4 API. Decommission will follow.


### PR DESCRIPTION
## Summary
- Updates Ongoing section title to `### Updated: Decommissioning of Launch External URL V1`
- Adds entry to Deprecations and Decommissions table linking to June 2026 RN (where it was first announced), with effective decommission date of June 23, 2026