### PR TITLE
EKPZH-4045: Update Report v3 Doc to Include Comma Separated Ok Fields

### DIFF
--- a/src/api-reference/expense/expense-report/v3.reports.markdown
+++ b/src/api-reference/expense/expense-report/v3.reports.markdown
@@ -34,8 +34,8 @@ Name|Type|Format|Description
 `offset`|`string`|`query`|Starting page offset
 `limit`|`Int32`|`query`|Number of records to return (default 25)
 `user`|`string`|`query`|Optional. The login ID of the report owner(s) to use when searching for reports. If the value is set to LoginID, reports for the report owner with this login ID value are returned. If the value is set to ALL, reports for all report owners are returned. If this parameter is not specified, reports for the OAuth Consumer are returned. The access token owner (OAuth Consumer) must have the Web Services Admin role to use this parameter.
-`approvalStatusCode`|`string`|`query`|The status code for the Approval Status. The values can include Concur Expense standard codes or custom codes. The Concur Expense standard code values are: A_AAFH - Report submission triggered an anomaly and fraud check; A_ACCO - Report is pending reviews; A_APPR - Report has been approved; A_EXTV - Report is pending external validation; A_FILE - Report has been submitted; A_NOTF - Report has not been submitted; A_PBDG - Report approval is pending Budget approval; A_PECO - Report approval is pending Cost object approval; A_PEND - Report is pending manager approval; A_PVAL - Report is pending prepayment validation; A_RESU - Report needs to be resubmitted; A_RHLD - Report submission is pending receipt images; A_TEXP - Report expired in approval queue. For custom codes, contact Concur Developer Support.
-`paymentStatusCode`|`string`|`query`|The payment status code for the report. The values can include Concur Expense standard codes or custom codes. The Concur Expense standard code values are: P_HOLD - Report payment is on hold; P_NOTP - Report has not been paid; P_PAID - Report has been paid; P_PAYC - Payment is confirmed. Some or all of the report expenses have been paid; P_PROC - Report is in process to be paid. For custom codes, contact Concur Developer Support.
+`approvalStatusCode`|`string`|`query`|The status code for the Approval Status. **Supports multiple values as a comma-separated list** (e.g., `A_PEND,A_ACCO`). The values can include Concur Expense standard codes or custom codes. The Concur Expense standard code values are: A_AAFH - Report submission triggered an anomaly and fraud check; A_ACCO - Report is pending reviews; A_APPR - Report has been approved; A_EXTV - Report is pending external validation; A_FILE - Report has been submitted; A_NOTF - Report has not been submitted; A_PBDG - Report approval is pending Budget approval; A_PECO - Report approval is pending Cost object approval; A_PEND - Report is pending manager approval; A_PVAL - Report is pending prepayment validation; A_RESU - Report needs to be resubmitted; A_RHLD - Report submission is pending receipt images; A_TEXP - Report expired in approval queue. For custom codes, contact Concur Developer Support.
+`paymentStatusCode`|`string`|`query`|The payment status code for the report. **Supports multiple values as a comma-separated list** (e.g., `P_NOTP,P_PROC`). The values can include Concur Expense standard codes or custom codes. The Concur Expense standard code values are: P_HOLD - Report payment is on hold; P_NOTP - Report has not been paid; P_PAID - Report has been paid; P_PAYC - Payment is confirmed. Some or all of the report expenses have been paid; P_PROC - Report is in process to be paid. For custom codes, contact Concur Developer Support.
 `currencyCode`|`string`|`query`|The 3-letter ISO 4217 currency code for the report currency. Example: USD.
 `paymentType`|`string`|`query`|The unique identifier for the payment type that is the payment type for at least one expense entry in the report. Use PaymentTypeID from Response of GET Expense Group Configurations V3 to obtain valid payment types.
 `reimbursementMethod`|`string`|`query`|The method the report owner will be reimbursed. VALUES: ADPPAYR - ADP Payroll; APCHECK - AP (Company Check); CNQRPAY - Expense Pay; PMTSERV - Other Payment Service. NOTE: PAY_PAL is NOT supported.
@@ -71,6 +71,12 @@ Name|Type|Format|Description
 
 ```
 https://www.concursolutions.com/api/v3.0/expense/reports?limit=15&user=ALL
+```
+
+#### Example with multiple status codes
+
+```
+https://www.concursolutions.com/api/v3.0/expense/reports?user=ALL&approvalStatusCode=A_PEND,A_ACCO
 ```
 
 ### JSON example of a successful response


### PR DESCRIPTION
Documentation updated successfully in `src/api-reference/expense/expense-report/v3.reports.markdown`. Three changes were made:

1. __`approvalStatusCode` parameter description__ — Added: "__Supports multiple values as a comma-separated list__ (e.g., `A_PEND,A_ACCO`)"

2. __`paymentStatusCode` parameter description__ — Added: "__Supports multiple values as a comma-separated list__ (e.g., `P_NOTP,P_PROC`)"

3. __New example URL__ added under the Request URL section:

   ```javascript
   https://www.concursolutions.com/api/v3.0/expense/reports?user=ALL&approvalStatusCode=A_PEND,A_ACCO
   ```

This makes it clear to developers that both parameters accept multiple comma-separated values in a single request.
