### PR TITLE
docs: add SSL certificate renewal preview to July 2026 release notes

### DIFF
--- a/src/tools-support/release-notes/api/2026-07-01.md
+++ b/src/tools-support/release-notes/api/2026-07-01.md
@@ -6,6 +6,44 @@ layout: reference
 
 ## New This Month
 
+### Preview: SSL Certificate Renewal for `*.concursolutions.com`, `usg.concursolutions.com`, and `usg.api.concursolutions.com`
+
+In August 2026, SAP Concur will renew the security certificates for `*.concursolutions.com` and Concur Cloud for Public Sector (`usg.concursolutions.com` and `usg.api.concursolutions.com`). In most cases, certificate renewal is automatic and transparent, and no action is required.
+
+Due to industry-wide changes implemented by our Certificate Authority, DigiCert, the maximum validity period for publicly trusted TLS certificates has been reduced to 199 days. As a result, SAP Concur certificates will be renewed more frequently than in previous years.
+
+> **Important:** As validity periods continue to shorten — to 199 days in 2026, 100 days in 2027, and 47 days in 2029 — SAP Concur will no longer be able to provide advance announcements for certificate renewals. Certificates will be rotated more frequently and automatically. Changes to Intermediate or Root CA certificates will still be announced in advance.
+
+> **Note:** This change is part of broader security improvements across the industry and has no impact on the security, availability, or trust of SAP Concur services.
+
+**`*.concursolutions.com` (US2, EU2, APJ1)**
+
+SAP Concur will issue a new certificate at 10PM PDT on August 26, 2026. The current certificate expires on September 18, 2026 at 23:59 GMT.
+
+**`usg.concursolutions.com` and `usg.api.concursolutions.com` (Concur Cloud for Public Sector)**
+
+SAP Concur will issue new certificates on the following schedule:
+
+Certificate|Implementation Date
+---|---
+`usg.concursolutions.com`|August 19, 2026 10PM PDT
+`usg.api.concursolutions.com`|August 24, 2026 10PM PDT
+
+As part of this renewal, the Client Authentication extended key usage will be removed from `usg.concursolutions.com` and `usg.api.concursolutions.com` certificates. This extension was not used as these certificates function as TLS server certificates for server authentication only. Its removal does not impact service functionality.
+
+**Certificate Pinning Guidance**
+
+Clients who have not pinned the expiring certificate do not need to take any action. **Most clients do not pin the certificate.**
+
+> **Note:** Certificate pinning is not recommended, and you do so at your own risk. If your implementation requires certificate pinning, pin the Intermediate or Root CA certificate instead of the leaf/end-entity certificate. Pinning the leaf certificate will result in frequent service disruptions as renewal cycles become shorter.
+
+For full details, including certificate download links, testing instructions, and feature activation, refer to Concur Shared Release Notes on SAP Help Portal:
+
+- [SSL Certificates Renewal for US2, EU2, and APJ1](https://help.sap.com/docs/sap-concur/concur-shared-release-notes/preview-ssl-certificates-renewal)
+- [SSL Certificate Renewal for Concur Cloud for Public Sector](https://help.sap.com/docs/sap-concur/concur-shared-release-notes/preview-ssl-certificate-renewal-for-concur-cloud-for-public-sector)
+
+Additional information about the 199-day certificate validity period is available in the documentation provided by [DigiCert](https://knowledge.digicert.com/alerts/public-tls-certificates-199-day-validity).
+
 ### Preview: Additions to Guest Information and Shop Requests in Hotel Service v4
 
 **Middle Name in Guest Information**


### PR DESCRIPTION
## Summary

Adds a Preview entry to the July 2026 API Release Notes covering the upcoming SSL certificate renewals for `*.concursolutions.com`, `usg.concursolutions.com`, and `usg.api.concursolutions.com`.

## What changed

- New first topic under **New This Month** in `2026-07-01.md`
- Covers both US2/EU2/APJ1 and Concur Cloud for Public Sector renewals in a single section
- Includes Important notice about end of advance renewal announcements
- Links to Concur Shared Release Notes on SAP Help Portal for full details

## What did NOT change

- No other files modified