### PR TITLE
feat: [HOTEL-39093] add singlePnr to requestorInfo object

### DIFF
--- a/src/api-explorer/v4-0/HotelService.swagger2.json
+++ b/src/api-explorer/v4-0/HotelService.swagger2.json
@@ -2116,6 +2116,11 @@
           "description": "Pseudo City Code or Office ID (OID) for the GDS account to be used for this booking (active or passive segment).",
           "type": "string",
           "example": "ABC123"
+        },
+        "singlePNR": {
+          "description": "Indicates if the booking should be made in a single PNR (Passenger Name Record) for all travelers. If true, all travelers will be booked under the same PNR. If false, each traveler will have their own PNR.",
+          "type": "boolean",
+          "default": false
         }
       },
       "required": [

--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
@@ -36,7 +36,8 @@ POST /hotels/search
   "loginId": "abc@concur.com",
   "bookingForSelf": true,
   "pcc": "ABC123",
-  "gdsName": "SABRE"
+  "gdsName": "SABRE",
+  "singlePNR": true
 },
   "numGuests": 1,
   "guestCountryCode": "CA",
@@ -201,7 +202,8 @@ POST /hotels/rates
   "loginId": "abc@concur.com",
   "bookingForSelf": true,
   "pcc": "ABC123",
-  "gdsName": "SABRE"
+  "gdsName": "SABRE",
+  "singlePNR": true
 },
   "hotelPropertyRefs": [
     {
@@ -418,7 +420,8 @@ POST /hotels/ratedetails
   "loginId": "abc@concur.com",
   "bookingForSelf": true,
   "pcc": "ABC123",
-  "gdsName": "SABRE"
+  "gdsName": "SABRE",
+  "singlePNR": true
 },
   "hotelPropertyRef": {
     "chainCode": "HH",
@@ -614,7 +617,8 @@ POST /hotels/ratedetails
   "loginId": "abc@concur.com",
   "bookingForSelf": true,
   "pcc": "ABC123",
-  "gdsName": "SABRE"
+  "gdsName": "SABRE",
+  "singlePNR": true
 },
   "hotelPropertyRef": {
     "chainCode": "HH",
@@ -821,7 +825,8 @@ POST /hotels/details
   "loginId": "abc@concur.com",
   "bookingForSelf": true,
   "pcc": "ABC123",
-  "gdsName": "SABRE"
+  "gdsName": "SABRE",
+  "singlePNR": true
 },
   "hotelCodes": [
     {
@@ -919,7 +924,8 @@ POST /hotels/reservation
     "loginId": "abc@concur.com",
     "bookingForSelf": false,
     "pcc": "ABC123",
-    "gdsName": "SABRE"
+    "gdsName": "SABRE",
+    "singlePNR": true
   },
   "ratePlanId": "44SM3FAsfvgcZs9ehGlNOQ",
   "guests": [
@@ -1256,7 +1262,8 @@ POST /hotels/reservation/read
   "loginId": "abc@concur.com",
   "bookingForSelf": true,
   "pcc": "ABC123",
-  "gdsName": "SABRE"
+  "gdsName": "SABRE",
+  "singlePNR": true
 },
   "confirmationCodes": [
     {
@@ -1477,7 +1484,8 @@ POST /hotels/reservation/modify
       "posRequestorId": "abc1234",
       "travelerUuid": "123e4567-e89b-12d3-a456-426614174000",
       "loginId": "abc@concur.com",
-      "bookingForSelf": true
+      "bookingForSelf": true,
+      "singlePNR": true
     },
     "ratePlanId": "44SM3FAsfvgcZs9ehGlNOQ",
     "guests": [
@@ -1783,7 +1791,8 @@ POST /hotels/reservation/cancel
   "loginId": "abc@concur.com",
   "bookingForSelf": true,
   "pcc": "ABC123",
-  "gdsName": "SABRE"
+  "gdsName": "SABRE",
+  "singlePNR": true
 },
   "confirmationCodes": [
     {

--- a/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
@@ -354,6 +354,7 @@ Information about Point of Sale (POS), traveler, and user associated with the re
 `bookingForSelf`|`boolean`|`true` / `false`|If `true`, the person logged in is making a booking for themselves.|
 `gdsName`|`string`|-|Name of the GDS (Global Distribution System) to be used for this booking (active or passive segment). Supported values: `SABRE`, `AMADEUS`, `TRAVELPORT`|
 `pcc`|`string`|-|Pseudo City Code or Office ID (OID) for the GDS account to be used for this booking (active or passive segment).|
+`singlePNR` | `boolean`|`true` / `false`| Reflects the Single PNR configuration
 
 ## <a id="schemaarranger"></a> Arranger
 


### PR DESCRIPTION
Include the new `singlePNR` field in the `requestorInfo` object schema, so CHS connector developers are aware of the new indicator available in shop requests.

<img width="733" height="614" alt="Screenshot 2026-07-21 at 15 37 43" src="https://github.com/user-attachments/assets/c34317c9-49c5-4c72-ad83-cdf55c22f68a" />
