### PR TITLE
docs: include displaySustainabilityProgram property

### DIFF
--- a/src/api-explorer/v4-0/HotelService.swagger2.json
+++ b/src/api-explorer/v4-0/HotelService.swagger2.json
@@ -2664,6 +2664,11 @@
           "description": "Name of certification in case when not possible to map to currently supported labels",
           "example": "Custom",
           "type": "string"
+        },
+        "displaySustainabilityProgram": {
+          "description": "Indicates if the sustainability award is shown as the property's sustainability program",
+          "example": false,
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md
@@ -155,7 +155,8 @@ POST /hotels/search
       "sustainabilityAwards": [
         {
           "label": "LEED",
-          "level": "Gold"
+          "level": "Gold",
+          "displaySustainabilityProgram": false
         }
       ],
       "acceptedPayments": [

--- a/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
+++ b/src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown
@@ -624,6 +624,7 @@ Award or certification related to sustainability awarded to the hotel. If certif
 `label`|[`SustainabilityProvider`](#schemasustainabilityprovider)|-|**Required** Name or label of the award/certification. Supported values: `GSTC`,`EARTH_CHECK`,`GREEN_GLOBE`,`GREEN_KEY`,`TRAVELIFE`,`GREEN_LEAF`,`LEED`,`GREEN_GROWTH_2050`,`GREEN_SEAL`,`HILTON_LIGHTSTAY`,`IHG_GREEN_ENGAGE`,`NORDIC_SWAN`,`ACTIVITY_GREEN`,`ADVENTURE_GREEN_ALASKA`,`ECO_CERTIFICATION_MALTA`,`GLOBAL_ECOSPHERE_RETREATS`,`GREAT_GREEN_DEAL`,`SEYCHELLES_SUSTAINABLE_TOURISM`,`GREEN_STAY`,`OTHER`|
 `level`|`string`|-|Optional level of certification.|
 `name` |`string`|-|Name of certification in case when not possible to map to currently supported labels (`OTHER` is used).|
+`displaySustainabilityProgram`|`boolean`|`true` \ `false`| Indicates if the sustainability award is shown as the property's sustainability program.|
 
 
 ## <a id="schemaemissioninfo"></a> EmissionInfo


### PR DESCRIPTION
## Summary
- Added new optional `displaySustainabilityProgram` boolean property to the SustainabilityAward schema
- Indicates whether the sustainability award should be displayed as the property's sustainability program

## Files Modified:
1. src/api-explorer/v4-0/HotelService.swagger2.json - Updated API schema definitions
2. src/api-reference/direct-connects/hotel-service-4/v4.endpoints.md - Added example request payloads
3. src/api-reference/direct-connects/hotel-service-4/v4.schemas.markdown - Updated schema documentation