### PR TITLE
feat: add API release notes for August 2026

### DIFF
--- a/src/tools-support/release-notes/api/2026-08-06.md
+++ b/src/tools-support/release-notes/api/2026-08-06.md
@@ -1,0 +1,91 @@
+---
+title: SAP Concur Developer Center - API Release Notes, August 2026
+layout: reference
+---
+# API Release Notes, August 2026
+
+## New This Month
+
+### Preview: Detokenizer v5 – Get Banking Info API
+
+The Detokenizer v5 API will include a new endpoint to retrieve bank account details:
+
+`POST /detokenizer/v5/bankaccounts/{loginId}`
+
+This endpoint returns the most recently modified active bank account for the given employee `loginId`, with sensitive fields decrypted and the full payload re-encrypted with the caller's AES symmetric key. Authentication requires a Company JWT with the `bankaccount.details.read` scope. This API will be available in US2, EU2, APJ1, and CCPS environments.
+
+The `/v5/publickey` endpoint must be called first — it will accept both `creditcardaccount.read` and `bankaccount.details.read` scopes.
+
+### Important! Upcoming Shutdown of Request V1, V3, and V3.1
+
+**Updated Effective Date: November 3, 2026**
+
+As previously announced, the Concur Request APIs v1.0, v3.0, and v3.1 have been decommissioned. These versions will be retired and no longer accessible as of November 3, 2026. Customers currently using these versions must migrate to the successor API, Request API V4, to ensure uninterrupted functionality. Please reach out to your Concur representative for more information.
+
+## Ongoing
+
+### Preview: SSL Certificate Renewal for `*.concursolutions.com`, `usg.concursolutions.com`, and `usg.api.concursolutions.com`
+
+In August 2026, SAP Concur will renew the security certificates for `*.concursolutions.com` and Concur Cloud for Public Sector (`usg.concursolutions.com` and `usg.api.concursolutions.com`). In most cases, certificate renewal is automatic and transparent, and no action is required.
+
+Due to industry-wide changes implemented by our Certificate Authority, DigiCert, the maximum validity period for publicly trusted TLS certificates has been reduced to 199 days. As a result, SAP Concur certificates will be renewed more frequently than in previous years.
+
+> **Important:** As validity periods continue to shorten — to 199 days in 2026, 100 days in 2027, and 47 days in 2029 — SAP Concur will no longer be able to provide advance announcements for certificate renewals. Certificates will be rotated more frequently and automatically. Changes to Intermediate or Root CA certificates will still be announced in advance.
+
+SAP Concur will issue new certificates on the following schedule:
+
+Certificate|Implementation Date|Applicable Data Centers
+---|---|---
+`usg.concursolutions.com`|August 19, 2026 10PM PDT|Concur Cloud for Public Sector
+`usg.api.concursolutions.com`|August 24, 2026 10PM PDT|Concur Cloud for Public Sector
+`*.concursolutions.com`|August 26, 2026 10PM PDT|US2, EU2, APJ1
+
+As part of this renewal, the Client Authentication extended key usage will be removed from `usg.concursolutions.com` and `usg.api.concursolutions.com` certificates. This extension was not used as these certificates function as TLS server certificates for server authentication only. Its removal does not impact service functionality.
+
+> **Note:** This change is part of broader security improvements across the industry and has no impact on the security, availability, or trust of SAP Concur services.
+
+**Certificate Pinning Guidance**
+
+Clients who have not pinned the expiring certificate do not need to take any action. **Most clients do not pin the certificate.**
+
+> **Note:** Certificate pinning is not recommended, and you do so at your own risk. If your implementation requires certificate pinning, pin the Intermediate or Root CA certificate instead of the leaf/end-entity certificate. Pinning the leaf certificate will result in frequent service disruptions as renewal cycles become shorter.
+
+For full details, including certificate download links, testing instructions, and feature activation, refer to Concur Shared Release Notes:
+
+- [SSL Certificates Renewal for US2, EU2, and APJ1](https://help.sap.com/docs/sap-concur/concur-shared-release-notes/preview-ssl-certificates-renewal)
+- [SSL Certificate Renewal for Concur Cloud for Public Sector](https://help.sap.com/docs/sap-concur/concur-shared-release-notes/preview-ssl-certificate-renewal-for-concur-cloud-for-public-sector)
+
+Additional information about the 199-day certificate validity period is available in the documentation provided by [DigiCert](https://knowledge.digicert.com/alerts/public-tls-certificates-199-day-validity).
+
+## Previews
+
+In general, this table lists items that will be shipping in the next 30-60 days. For a broader view of features that are coming, please see our [Road Map Explorer](https://roadmaps.sap.com/board?PRODUCT=089E017A62AB1EDA94C15F5EDB3400E1&range=CURRENT-LAST#Q3%202024).
+
+Date|API|Preview
+---|---|---
+[06/2026](/tools-support/release-notes/api/2026-06-03.html)|Meetings API|The Meetings API will provide customers and partners with a seamless way to create, manage, and integrate meetings within SAP Concur, supporting meetings created in Concur and third-party platforms.
+[06/2026](/tools-support/release-notes/api/2026-06-03.html)|Trips v5 API with Configurable Trip Event Subscriptions|The Trips v5 API will provide a scalable and performant way to retrieve trip data based on a configurable event-based subscription model, with divisional view support for TMC partners.
+[01/2026](/tools-support/release-notes/api/2026-01-12.html)|Additions to Reservation and Search Requests in Hotel Service v4|This API will add travel arranger details to a reservation request. It will also add the GIATA ID to a hotel search request.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|New Attributes for Spend User v4.1|The Spend User v4.1 API will allow you to access the `processorReportAccess` field in the User Preference extension and the User extension will allow you to access the following fields: `officeLocationCountry`, `officeLocationStateProvince`, `officeLocationCity`.
+[04/2025](/tools-support/release-notes/api/2025-04-03.html)|New Fields Added to Financial Integration Services (FIS) v4 API|For customers of the Concur Expense Professional Edition using the Financial Integration Services (FIS) v4 API, additional fields will be included in the Expense report document payload and mileage fields will be added to the payroll document schema.
+[05/2024](/tools-support/release-notes/api/archive/2024-05-09.html)|Retention Period for Credit Card Data Files|For compliance reasons, SAP Concur will be implementing a process wherein card data files received from external sources (Issuing banks, Card associations) will be deleted from systems after 90 days.
+[01/2024](/tools-support/release-notes/api/archive/2024-01-11.html)|Hotel Service v4|Updates to Hotel Service v4 that will remove existing elements from the <Profiles> section relating to gender and name prefixes.
+
+## Deprecations and Decommissions
+
+APIs are being deprecated or decommissioned in accordance with the [SAP Concur API Lifecycle & Deprecation Policy](/tools-support/deprecation-policy.html).
+
+Date|API|Details
+---|---|---
+[06/2026](/tools-support/release-notes/api/2026-06-03.html)|Decommission of Launch External URL V1|Effective June 23, 2026, the Launch External URL V1 callout API was decommissioned. Customers must migrate to Launch External URL V4, which provides full functional equivalence with no known gaps.
+[06/2026](/tools-support/release-notes/api/2026-06-03.html)|Deprecation of Company Cards Transactions v1|Effective June 8, 2026, the Company Cards Transactions v1 API was deprecated. This has been replaced by Cards v4 API. Decommission will follow.
+[10/2025](/tools-support/release-notes/api/2025-10-02.html)|Deprecation of Locations v3|Effective October 10, 2025, the Locations v3 API will be deprecated. This has been replaced by Localities v5. Decommission will follow.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|Deprecation of Expense Group Configurations v3|Effective June 26, 2025, the Expense Group Configurations v3 API was deprecated. This has been replaced by the Expense Configuration v4 API. Decommission will follow.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|Deprecation of Expense v3 DELETE|Effective June 26, 2025, Expense v3 DELETE was deprecated. This has been replaced by Expense v4 Delete. Decommission will follow.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|Deprecation of Attendees v3 API|Effective July 1, 2025, the Attendees v3 API was deprecated. This has been replaced by Attendees v4. Decommission will follow.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|Deprecation of Attendee Types v3 API|Effective July 1, 2025, the Attendee Types v3 API was deprecated. This has been replaced by Attendee Types v4. Decommission will follow.
+[04/2025](/tools-support/release-notes/api/2025-04-03.html)|Deprecation of Attendees v1, v1.1, and v2|Effective October 9, 2018, we have deprecated the Attendees v1, v1.1, and v2 APIs. Decommission will follow.
+[03/2024](/tools-support/release-notes/api/archive/2024-03-14.html)|Deprecation of Spend User Retrieval 4.0.|The decommission of password provisioning via file import will occur in April 2025.
+[01/2023](/tools-support/release-notes/api/archive/2023-01-05.html)|Move from the Travel Request External Validation Callout v1 to the Event Subscription Service (ESS)|This callout was designed to work with the Concur Request v1 API that is in the process of being decommissioned. Users are strongly recommended to move to the Event Subscription Services (ESS) in order to subscribe to the [Request events](https://developer.concur.com/api-reference/ess/v4.event-subscription.html).
+[01/2021](/tools-support/release-notes/api/archive/2021-01-22.html#planned-list-deprecation)|List v3 API|Effective April 16, 2021, we have deprecated the List v3 API. This API is replaced by the [List v4](/api-reference/common/lists/v4.list.html) API. List v3 is planned to be retired in a future release.
+[01/2021](/tools-support/release-notes/api/archive/2021-01-22.html#planned-list-item-deprecation)|List Item v3 API|Effective April 16, 2021, we have deprecated the List Item v3 API. This API is replaced by the [List Item v4](/api-reference/common/list-item/v4.list-item.html) API. List Item v3 is planned to be retired in a future release. Please migrate to the [List Item v4](/api-reference/common/list-item/v4.list-item.html) API as soon as possible.


### PR DESCRIPTION
Adds the API release notes file for August 2026.

## Changes
- New file: `src/tools-support/release-notes/api/2026-08-06.md`

## Contents
- **New This Month:** Preview of Detokenizer v5 Get Banking Info API; Request V1/V3/V3.1 shutdown updated effective date (November 3, 2026)
- **Ongoing:** SSL Certificate Renewal preview (implementation dates in August 2026)
- **Previews table:** Carried over from July (Meetings API, Trips v5, Hotel Service v4 additions, Spend User v4.1, FIS v4, Credit Card Data retention, Hotel Service v4 profiles)
- **Deprecations and Decommissions:** Carried over from July