### PR TITLE
fix: update listing form link and convert absolute links to relative in marketing toolkit

### DIFF
--- a/src/manage-apps/go-market-docs/app-center-partner-marketing-toolkit.markdown
+++ b/src/manage-apps/go-market-docs/app-center-partner-marketing-toolkit.markdown
@@ -29,7 +29,7 @@ Acceptable|Branding|Notes
 :---:|---|---
 &#9989;|We are an SAP Concur partner.|-
 &#9989;|![SAP Concur Partner App Center Logo](./partner-marketing-toolkit-images/app-center-partner-marketing-toolkit-logo-brand-sap-concur-partner.png)|-
-&#9989;|![SAP Concur Partner App Center Logo](./partner-marketing-toolkit-images/app-center-partner-marketing-toolkit-logo-brand-sap-concur-partner-app-center.png)|Download the font treatment [here](https://developer.concur.com/manage-apps/go-market-docs/app-center-partner-marketing-toolkit.html#font-treatment-download-links). Make sure to follow the [Font Treatment brand guidelines](/manage-apps/go-market-docs/sap-concur-partner-guidelines-addendum.pdf) for use. ​
+&#9989;|![SAP Concur Partner App Center Logo](./partner-marketing-toolkit-images/app-center-partner-marketing-toolkit-logo-brand-sap-concur-partner-app-center.png)|Download the font treatment [here](/manage-apps/go-market-docs/app-center-partner-marketing-toolkit.html#font-treatment-download-links). Make sure to follow the [Font Treatment brand guidelines](/manage-apps/go-market-docs/sap-concur-partner-guidelines-addendum.pdf) for use. ​
 Specific cases only|![SAP Concur logo](./partner-marketing-toolkit-images/app-center-marketing-toolkit-sap-concur-logo-blue.png)|Partners may use the SAP Concur logo only in specific situations, such as your integration or connection landing page UI or in a list of all of your partnerships. You must follow brand guidelines and submit content for review.
 &#10060;|![Do Not Use SAP Logo](./partner-marketing-toolkit-images/app-center-partner-marketing-toolkit-logo-brand-sap-logo.png)|Partners are **not** permitted to use the SAP corporate logo.
 &#10060;|![Do Not Use Concur Logo](./partner-marketing-toolkit-images/app-center-partner-marketing-toolkit-logo-brand-concur-logo.png)|Do **not** use an outdated “Concur” logo when creating materials.
@@ -238,7 +238,7 @@ Work with Certification Project Manager to approve your landing page content, an
 
 #### <a name="Connection Page"></a>Connection Page
 
-The Connect page that customers use to enable the integration should follow our UX Guidelines for [Enterprise](https://developer.concur.com/manage-apps/go-market-docs/app-center-ux-guidelines-enterprise.html#guideline-checklist-landing-page) and [User Connection](https://developer.concur.com/manage-apps/go-market-docs/app-center-ux-guidelines-consumer.html) apps. 
+The Connect page that customers use to enable the integration should follow our UX Guidelines for [Enterprise](/manage-apps/go-market-docs/app-center-ux-guidelines-enterprise.html#guideline-checklist-landing-page) and [User Connection](/manage-apps/go-market-docs/app-center-ux-guidelines-consumer.html) apps. 
 
 ### <a name="success-stories"></a> Partner Success Stories
 97% of B2B customers surveyed by Demand Gen Reports claimed that testimonials and peer recommendations are the most reliable type of content. We couldn’t agree more! Our case studies are used for client engagements, incorporated into campaigns, and distributed throughout various channels company-wide.​
@@ -395,7 +395,7 @@ etc.
 ### <a name="listing-process"></a>App Center Listing Creation and Update Process
 
 1. Send your completed content to your Certification Project Manager for review. This includes your:
-	* **App Center listing form** ([link](/manage-apps/go-market-docs/app-center-partner-listing-form.docx))
+	* **App Center listing form** ([link](/manage-apps/go-market-docs/app-center-partner-listing-form-v2.docx))
 		* Tip: Make sure to pay attention to the character limits and be sure your long description includes a call to action
 	* **Listing images**
 		* Tip: Size requirements are at the bottom of the listing form
@@ -406,7 +406,7 @@ etc.
 	* Please plan for a 10 to 14-day turnaround window for the review process.
 3. Once your content is finalized, your listing will be queued for launch on an agreed-upon date. 
 	* Your app must be certified prior to launch. 
-	* User Connection apps are launched on the [SAP Concur release dates](https://developer.concur.com/manage-apps/go-market-docs/apps-for-me-release-schedule.html).
+	* User Connection apps are launched on the [SAP Concur release dates](/manage-apps/go-market-docs/apps-for-me-release-schedule.html).
 
 ### <a name="approval-process"></a>Approval Process
 


### PR DESCRIPTION
## Summary

- Updates the App Center listing form link to point to the v2 file (`app-center-partner-listing-form-v2.docx`)
- Converts `developer.concur.com` absolute links to relative links for: font treatment download, UX Guidelines (Enterprise and User Connection), and release schedule page

## Test plan
- [ ] Verify listing form link downloads the v2 file
- [ ] Verify relative links resolve correctly on the preview site