### PR TITLE
docs: add August 2026 release notes to left nav and index

### DIFF
--- a/src/_data/sidebars/tools-support.yml
+++ b/src/_data/sidebars/tools-support.yml
@@ -5,6 +5,8 @@
 - title: Developer Platform Release Notes
   url: ''
   children:
+      - title: August 2026
+        url: /tools-support/release-notes/api/2026-08-06.html
       - title: July 2026
         url: /tools-support/release-notes/api/2026-07-01.html
       - title: June 2026

--- a/src/tools-support/release-notes/index.markdown
+++ b/src/tools-support/release-notes/index.markdown
@@ -6,6 +6,7 @@ layout: reference
 
 ## Developer Platform Release Notes
 
+* [August 2026](./api/2026-08-06.html)
 * [July 2026](./api/2026-07-01.html)
 * [June 2026](./api/2026-06-03.html)
 * [May 2026](./api/2026-05-04.html)


### PR DESCRIPTION
## Summary

- Adds August 2026 entry to the left navigation (`src/_data/sidebars/tools-support.yml`)
- Adds August 2026 entry to the release notes index page (`src/tools-support/release-notes/index.markdown`)

Links to `2026-08-06.html` (added in PR #1868).