### PR TITLE
ci: upgrade CircleCI config from version 2 to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     working_directory: ~/test-repo
@@ -62,8 +62,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - 5a:be:54:43:62:2b:5f:ed:19:c3:6a:98:87:aa:38:42
-workflows:         
-  version: 2
+workflows:
   test-deploy:
     jobs:
       - build:


### PR DESCRIPTION
## Summary

- Upgrades CircleCI config `version` from `2` to `2.1` (version 2.0 is being retired)
- Removes the redundant `version: 2` line inside the `workflows` block (not needed in 2.1)

No changes to jobs, steps, or deployment logic.