### PR TITLE
Add Meetings API v4 to Dev Center (MEET-698)

### DIFF
--- a/src/_data/sidebars/api-explorer.yml
+++ b/src/_data/sidebars/api-explorer.yml
@@ -110,6 +110,8 @@
         url: https://api.sap.com/api/ConcurExpenseListItems/overview
       - title: List Item Bulk
         url: https://api.sap.com/api/ConcurListItemBulk/overview
+      - title: Meetings
+        url: /api-explorer/v4-0/Meetings.html
       - title: Purchase Requests
         url: https://api.sap.com/api/ConcurInvoicePurchaseRequest/overview
       - title: Quick Expenses

--- a/src/_data/sidebars/api-guides.yml
+++ b/src/_data/sidebars/api-guides.yml
@@ -53,6 +53,11 @@
   children:
       - title: Payment Provider Integration - paying customers' invoices
         url: /api-guides/invoice/payment-provider-integration.html
+- title: Meetings
+  url: ''
+  children:
+      - title: Third-Party Meetings Integration Guide
+        url: /api-guides/meetings/meetings-integration-guide.html
 - title: Testing App Center Partner Applications
   url: /api-guides/preproduction-testing.html
 - title: Profile

--- a/src/_data/sidebars/api-reference.yml
+++ b/src/_data/sidebars/api-reference.yml
@@ -298,6 +298,10 @@
         url: /api-reference/travel/itinerary/booking/booking-resource.html
       - title: Itinerary v4
         url: /api-reference/travel/itinerary-v4/v4.itinerary.html
+      - title: Meetings v4 – Getting Started
+        url: /api-reference/travel/v4.meetings-get-started.html
+      - title: Meetings v4 Endpoints
+        url: /api-reference/travel/v4.meetings-endpoints.html
 - title: Travel Allowance v4
   url: ''
   children:

--- a/src/api-explorer/v4-0/Meetings.markdown
+++ b/src/api-explorer/v4-0/Meetings.markdown
@@ -1,0 +1,7 @@
+---
+title: Meetings
+layout: reference
+reference-type: swagger
+---
+{% include prerelease.html %} 
+{% swagger /api-explorer/v4-0/Meetings.oas3.json %}

--- a/src/api-explorer/v4-0/Meetings.oas3.json
+++ b/src/api-explorer/v4-0/Meetings.oas3.json
@@ -1,0 +1,2086 @@
+{
+  "openapi": "3.0.3",
+  "x-sap-shortText": "Manage Concur meetings and their attendees, including third-party partner meeting integration",
+  "info": {
+    "title": "Concur Meetings API",
+    "version": "v4",
+    "description": "API for managing meetings and attendees within SAP Concur.\n\nSupports two primary use cases:\n1. **Concur Meetings** – Meetings created directly within Concur via Meetings Admin UI or Joule\n2. **Third-Party Meetings** – Meetings created by external partners (e.g., Cvent) via API integration\n\nThis is the partner-facing edition of the spec. Internal-only operations are not included.\n",
+    "termsOfService": "https://developer.concur.com/Terms-of-Use.html"
+  },
+  "servers": [
+    {
+      "url": "https://us.api.concursolutions.com/meetings/v4",
+      "description": "US Production"
+    },
+    {
+      "url": "https://emea.api.concursolutions.com/meetings/v4",
+      "description": "EMEA Production"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Meetings",
+      "description": "Meeting management operations"
+    },
+    {
+      "name": "Attendees",
+      "description": "Attendee management operations"
+    },
+    {
+      "name": "Authentication",
+      "description": "Non-employee attendee authentication"
+    }
+  ],
+  "paths": {
+    "/meetings": {
+      "get": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.read"
+            ]
+          }
+        ],
+        "tags": [
+          "Meetings"
+        ],
+        "operationId": "listMeetings",
+        "summary": "List all meetings",
+        "description": "Retrieve all meetings for a company with optional filtering. Use `attendeeId` with date params for meeting match.",
+        "parameters": [
+          {
+            "name": "companyId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Company UUID. Required — scopes listing to this company."
+          },
+          {
+            "name": "attendeeId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Filter meetings where this user is an attendee. Used for meeting match when combined with startDateFrom/startDateTo and status=active."
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "cancelled",
+                "completed"
+              ]
+            },
+            "description": "Filter by meeting status"
+          },
+          {
+            "name": "startDateFrom",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "Filter meetings starting from this date (ISO 8601)"
+          },
+          {
+            "name": "startDateTo",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "Filter meetings starting before this date (ISO 8601)"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of meetings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meetings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Meeting"
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.write"
+            ]
+          }
+        ],
+        "tags": [
+          "Meetings"
+        ],
+        "operationId": "createMeeting",
+        "summary": "Create a new meeting",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MeetingCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Meeting created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeetingCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/meetings/{meetingId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/MeetingId"
+        }
+      ],
+      "get": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.read"
+            ]
+          }
+        ],
+        "tags": [
+          "Meetings"
+        ],
+        "operationId": "getMeeting",
+        "summary": "Get full meeting details (metadata + settings + discounts)",
+        "description": "Retrieve all information about a specific meeting. For partial data, use the /metadata, /settings, or /discounts sub-resource endpoints.",
+        "responses": {
+          "200": {
+            "description": "Meeting details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Meeting"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          }
+        }
+      },
+      "patch": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.write"
+            ]
+          }
+        ],
+        "tags": [
+          "Meetings"
+        ],
+        "operationId": "updateMeeting",
+        "summary": "Update a meeting",
+        "description": "Update an existing meeting using partial-merge semantics per RFC 7396 — fields omitted from the body retain their existing values.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/MeetingUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Meeting updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Meeting"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.write"
+            ]
+          }
+        ],
+        "tags": [
+          "Meetings"
+        ],
+        "operationId": "deleteMeeting",
+        "summary": "Delete a meeting (soft delete)",
+        "description": "Soft-delete a meeting by setting status to cancelled. Only allowed for meetings with no bookings.",
+        "responses": {
+          "204": {
+            "description": "Meeting deleted"
+          },
+          "400": {
+            "description": "Meeting has existing bookings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "errorCode": "HAS_BOOKINGS",
+                      "errorMessage": "Cannot delete meeting with existing bookings"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          }
+        }
+      }
+    },
+    "/meetings/{meetingId}/metadata": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/MeetingId"
+        }
+      ],
+      "get": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.read"
+            ]
+          }
+        ],
+        "tags": [
+          "Meetings"
+        ],
+        "operationId": "getMeetingMetadata",
+        "summary": "Get meeting metadata only",
+        "description": "Retrieve core meeting information, excluding advance settings and discounts.",
+        "responses": {
+          "200": {
+            "description": "Meeting metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeetingMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          }
+        }
+      }
+    },
+    "/meetings/{meetingId}/settings": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/MeetingId"
+        }
+      ],
+      "get": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.read"
+            ]
+          }
+        ],
+        "tags": [
+          "Meetings"
+        ],
+        "operationId": "getMeetingSettings",
+        "summary": "Get advance settings only",
+        "description": "Retrieve only the advance settings for a specific meeting.",
+        "responses": {
+          "200": {
+            "description": "Meeting advance settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeetingSettingsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          }
+        }
+      }
+    },
+    "/meetings/{meetingId}/discounts": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/MeetingId"
+        }
+      ],
+      "get": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.read"
+            ]
+          }
+        ],
+        "tags": [
+          "Meetings"
+        ],
+        "operationId": "getMeetingDiscounts",
+        "summary": "Get discounts only",
+        "description": "Retrieve only the discounts for a specific meeting, with optional filtering by travel type.",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "air",
+                "car",
+                "hotel",
+                "rail"
+              ]
+            },
+            "description": "Filter by travel type"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Meeting discounts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeetingDiscountsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          }
+        }
+      }
+    },
+    "/meetings/{meetingId}/history": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/MeetingId"
+        }
+      ],
+      "get": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.read"
+            ]
+          }
+        ],
+        "tags": [
+          "Meetings"
+        ],
+        "operationId": "listMeetingHistory",
+        "summary": "List meeting history",
+        "description": "Returns audit history rows for a meeting and its child entities, newest first.\nA single PUT on a meeting can produce up to three rows: METADATA (the meeting record),\nSETTINGS, and one DISCOUNT row per affected discount. Attendee history is emitted\nby the attendee endpoints. Use `entityType` to narrow the result set.\n",
+        "parameters": [
+          {
+            "name": "entityType",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "METADATA",
+                "SETTINGS",
+                "DISCOUNT",
+                "ATTENDEE"
+              ]
+            },
+            "description": "Restrict to a single child-entity type. Same vocabulary as the response's `sourceEntityType`."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            }
+          },
+          {
+            "name": "nextToken",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Opaque pagination token returned by a previous call."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "History page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HistoryListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          }
+        }
+      }
+    },
+    "/meetings/{meetingId}/attendees": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/MeetingId"
+        }
+      ],
+      "get": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.read"
+            ]
+          }
+        ],
+        "tags": [
+          "Attendees"
+        ],
+        "operationId": "listAttendees",
+        "summary": "List meeting attendees",
+        "description": "Retrieve all attendees for a specific meeting.",
+        "parameters": [
+          {
+            "name": "bookingStatus",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "booked",
+                "cancelled"
+              ]
+            },
+            "description": "Filter by booking status"
+          },
+          {
+            "name": "profileType",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "employee",
+                "nonEmployee"
+              ]
+            },
+            "description": "Filter by profile type"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of attendees",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "attendees": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Attendee"
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.write"
+            ]
+          }
+        ],
+        "tags": [
+          "Attendees"
+        ],
+        "operationId": "addAttendee",
+        "summary": "Add single attendee",
+        "description": "Add a single attendee to a meeting.\n\n**Profile Resolution Logic:**\n1. If `concurUuid` is provided, use the existing profile (validates against `concurLoginId` if both provided)\n2. If not, attempt to match by `email` within the company\n3. If no match found and `profileType` is `nonEmployee`, create a Sponsored Guest profile with type \"Meeting Traveler\"\n4. If no match found and `profileType` is `employee`, return an error\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendeeCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Attendee added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendeeCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          },
+          "409": {
+            "description": "Duplicate attendee",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "errorCode": "DUPLICATE_ATTENDEE",
+                      "errorMessage": "Attendee with this email already exists for this meeting"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/meetings/{meetingId}/attendees/bulk": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/MeetingId"
+        }
+      ],
+      "post": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.write"
+            ]
+          }
+        ],
+        "tags": [
+          "Attendees"
+        ],
+        "operationId": "addAttendeesBulk",
+        "summary": "Add multiple attendees",
+        "description": "Add multiple attendees to a meeting in a single request. Returns HTTP 207 Multi-Status: the `results[]` array carries per-item success or error; check `results[i].status` for each.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "attendees"
+                ],
+                "properties": {
+                  "attendees": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AttendeeCreate"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "207": {
+            "description": "Multi-status response — per-item success or error in results[]",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkAttendeeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/MeetingNotFound"
+          }
+        }
+      }
+    },
+    "/meetings/{meetingId}/attendees/{attendeeId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/MeetingId"
+        },
+        {
+          "$ref": "#/components/parameters/AttendeeId"
+        }
+      ],
+      "get": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.read"
+            ]
+          }
+        ],
+        "tags": [
+          "Attendees"
+        ],
+        "operationId": "getAttendee",
+        "summary": "Get attendee details",
+        "description": "Retrieve details for a specific attendee.",
+        "responses": {
+          "200": {
+            "description": "Attendee details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Attendee"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/AttendeeNotFound"
+          }
+        }
+      },
+      "patch": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.write"
+            ]
+          }
+        ],
+        "tags": [
+          "Attendees"
+        ],
+        "operationId": "updateAttendee",
+        "summary": "Update attendee",
+        "description": "Update attendee information using partial-merge semantics per RFC 7396 — fields omitted from the body retain their existing values.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendeeUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Attendee updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Attendee"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/AttendeeNotFound"
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.write"
+            ]
+          }
+        ],
+        "tags": [
+          "Attendees"
+        ],
+        "operationId": "removeAttendee",
+        "summary": "Remove attendee",
+        "description": "Remove an attendee from a meeting.",
+        "parameters": [
+          {
+            "name": "deleteProfile",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "If true and attendee is a non-employee with no other associations, delete their profile"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Attendee removed"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/AttendeeNotFound"
+          }
+        }
+      }
+    },
+    "/meetings/{meetingId}/attendees/{attendeeId}/login-url": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/MeetingId"
+        },
+        {
+          "$ref": "#/components/parameters/AttendeeId"
+        }
+      ],
+      "post": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.write"
+            ]
+          }
+        ],
+        "tags": [
+          "Authentication"
+        ],
+        "operationId": "generateLoginUrl",
+        "summary": "Generate OTP login URL for a non-employee attendee",
+        "description": "Generate an OTP-based login URL that partners render as the \"Book Travel\" link for non-employee attendees.\nThe partner passes their OAuth credentials as form parameters. The Meetings API validates the request\nand proxies the credentials to the Auth service OTP endpoint (which internally uses CTE credentials to generate the OTP).\n\n**Validation performed:**\n1. Attendee exists and is a Sponsored Guest of type \"Meeting Traveler\"\n2. Attendee belongs to the specified meeting\n3. Meeting belongs to the calling partner's company\n4. Partner is listed as the `thirdPartyPartnerId` for the meeting\n\n**Note (documented deviation):** `client_id` and `client_secret` are sent as form-encoded parameters\n(`application/x-www-form-urlencoded`) in addition to the standard `Authorization: Bearer` header.\nSee Q7 deviation in the API Design Review Checklist for the defense-in-depth rationale: this endpoint\nmints a one-time login URL that authenticates a non-employee meeting attendee into Concur Travel, and\nre-authenticating the partner with the same credentials they used at the OAuth token endpoint is a\ndeliberate additional check.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "client_id",
+                  "client_secret"
+                ],
+                "properties": {
+                  "client_id": {
+                    "type": "string",
+                    "description": "Partner's AppCenter client ID"
+                  },
+                  "client_secret": {
+                    "type": "string",
+                    "format": "password",
+                    "description": "Partner's AppCenter client secret"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OTP login URL generated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginUrlResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Attendee is not a Meeting Traveler or partner is not authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "notMeetingTraveler": {
+                    "value": {
+                      "errors": [
+                        {
+                          "errorCode": "NOT_MEETING_TRAVELER",
+                          "errorMessage": "Attendee is not a Sponsored Guest of type \"Meeting Traveler\""
+                        }
+                      ]
+                    }
+                  },
+                  "partnerNotAuthorized": {
+                    "value": {
+                      "errors": [
+                        {
+                          "errorCode": "PARTNER_NOT_AUTHORIZED",
+                          "errorMessage": "Partner is not listed as the third-party vendor for this meeting"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/AttendeeNotFound"
+          },
+          "502": {
+            "description": "OTP generation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "errorCode": "OTP_GENERATION_FAILED",
+                      "errorMessage": "Upstream OTP endpoint returned an error"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://www.concursolutions.com/oauth2/v0/token",
+            "scopes": {
+              "meetings.read": "Read meetings, attendees, history",
+              "meetings.write": "Create / update / delete meetings, attendees, login URLs"
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "MeetingId": {
+        "name": "meetingId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "description": "Meeting identifier"
+      },
+      "AttendeeId": {
+        "name": "attendeeId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "description": "Attendee identifier"
+      },
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "default": 20,
+          "minimum": 1,
+          "maximum": 100
+        },
+        "description": "Number of results per page"
+      },
+      "Offset": {
+        "name": "offset",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0
+        },
+        "description": "Pagination offset"
+      }
+    },
+    "schemas": {
+      "Meeting": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "cancelled",
+              "completed"
+            ]
+          },
+          "locationName": {
+            "type": "string"
+          },
+          "airport": {
+            "type": "string",
+            "description": "Nearest airport IATA code"
+          },
+          "startDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "IANA time zone identifier (e.g., America/Los_Angeles)"
+          },
+          "travelConfigId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "alwaysUseUserTravelConfig": {
+            "type": "boolean",
+            "default": false
+          },
+          "billingCode": {
+            "type": "string"
+          },
+          "barLevel1Star": {
+            "type": "string"
+          },
+          "thirdPartyPartnerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "Third-party partner identifier (UUID)"
+          },
+          "advanceSettings": {
+            "$ref": "#/components/schemas/AdvanceSettings"
+          },
+          "discounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Discount"
+            }
+          },
+          "partnerMeetingId": {
+            "type": "string",
+            "description": "Meeting ID in partner system (e.g., Cvent event ID)"
+          },
+          "createdBy": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MeetingCreate": {
+        "type": "object",
+        "required": [
+          "companyId",
+          "name",
+          "locationName",
+          "airport",
+          "startDateTime",
+          "endDateTime",
+          "timeZone",
+          "travelConfigId"
+        ],
+        "properties": {
+          "companyId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Company UUID. Required for POST (identifies which company the meeting belongs to)."
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "description": {
+            "type": "string"
+          },
+          "locationName": {
+            "type": "string"
+          },
+          "airport": {
+            "type": "string",
+            "description": "Nearest airport IATA code"
+          },
+          "startDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "IANA time zone identifier (e.g., America/Los_Angeles)"
+          },
+          "travelConfigId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "alwaysUseUserTravelConfig": {
+            "type": "boolean",
+            "default": false
+          },
+          "billingCode": {
+            "type": "string"
+          },
+          "barLevel1Star": {
+            "type": "string"
+          },
+          "thirdPartyPartnerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "advanceSettings": {
+            "$ref": "#/components/schemas/AdvanceSettings"
+          },
+          "discounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscountCreate"
+            }
+          },
+          "partnerMeetingId": {
+            "type": "string",
+            "description": "Meeting ID in partner system"
+          }
+        }
+      },
+      "MeetingUpdate": {
+        "type": "object",
+        "description": "Partial update payload for PUT /v4/meetings/{meetingId}. All fields are optional;\nomitted fields keep their existing values. Format constraints (UUID, ISO-8601 datetime\nwith timezone) are still enforced when a field is supplied.\n",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "description": {
+            "type": "string"
+          },
+          "locationName": {
+            "type": "string"
+          },
+          "airport": {
+            "type": "string",
+            "description": "Nearest airport IATA code"
+          },
+          "startDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "IANA time zone identifier (e.g., America/Los_Angeles)"
+          },
+          "travelConfigId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "alwaysUseUserTravelConfig": {
+            "type": "boolean"
+          },
+          "billingCode": {
+            "type": "string"
+          },
+          "barLevel1Star": {
+            "type": "string"
+          },
+          "thirdPartyPartnerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "advanceSettings": {
+            "$ref": "#/components/schemas/AdvanceSettings"
+          },
+          "discounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscountCreate"
+            }
+          },
+          "partnerMeetingId": {
+            "type": "string",
+            "description": "Meeting ID in partner system"
+          },
+          "owner": {
+            "type": "object",
+            "description": "Meeting owner identification",
+            "properties": {
+              "concurUuid": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "concurLoginId": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "MeetingCreateResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Meeting"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "deepLinkTemplate": {
+                "type": "string",
+                "description": "URL template for attendee booking deep links"
+              }
+            }
+          }
+        ]
+      },
+      "MeetingMetadata": {
+        "type": "object",
+        "description": "Core meeting fields excluding advanceSettings and discounts.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "cancelled",
+              "completed"
+            ]
+          },
+          "locationName": {
+            "type": "string"
+          },
+          "airport": {
+            "type": "string",
+            "description": "Nearest airport IATA code"
+          },
+          "startDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "IANA time zone identifier (e.g., America/Los_Angeles)"
+          },
+          "travelConfigId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "alwaysUseUserTravelConfig": {
+            "type": "boolean",
+            "default": false
+          },
+          "billingCode": {
+            "type": "string"
+          },
+          "barLevel1Star": {
+            "type": "string"
+          },
+          "thirdPartyPartnerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "Third-party partner identifier (UUID)"
+          },
+          "partnerMeetingId": {
+            "type": "string",
+            "description": "Meeting ID in partner system (e.g., Cvent event ID)"
+          },
+          "createdBy": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MeetingSettingsResponse": {
+        "type": "object",
+        "properties": {
+          "meetingId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "advanceSettings": {
+            "$ref": "#/components/schemas/AdvanceSettings"
+          }
+        }
+      },
+      "MeetingDiscountsResponse": {
+        "type": "object",
+        "properties": {
+          "meetingId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "discounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Discount"
+            }
+          }
+        }
+      },
+      "HistoryItem": {
+        "type": "object",
+        "properties": {
+          "historyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "meetingId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceEntityType": {
+            "type": "string",
+            "enum": [
+              "METADATA",
+              "SETTINGS",
+              "DISCOUNT",
+              "ATTENDEE"
+            ]
+          },
+          "sourceEntityId": {
+            "type": "string",
+            "description": "For METADATA/SETTINGS this is the meetingId; for DISCOUNT/ATTENDEE the child entity ID."
+          },
+          "version": {
+            "type": "integer",
+            "description": "Monotonically increasing per (meetingId, sourceEntityType, sourceEntityId)."
+          },
+          "changeAction": {
+            "type": "string",
+            "enum": [
+              "CREATE",
+              "UPDATE",
+              "DELETE"
+            ]
+          },
+          "changedBy": {
+            "type": "string",
+            "description": "User UUID for JWT-authenticated callers; cert CN for mTLS."
+          },
+          "changedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "snapshot": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "For CREATE: per-field `{ \"<field>\": { \"after\": <value> } }` map of the created entity.\nFor DELETE: per-field `{ \"<field>\": { \"before\": <value> } }` map of the deleted entity.\nFor UPDATE: per-field `{ \"<field>\": { \"before\": <old>, \"after\": <new> } }` for fields that actually changed.\n"
+          }
+        }
+      },
+      "HistoryListResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HistoryItem"
+            }
+          },
+          "nextToken": {
+            "type": "string",
+            "nullable": true,
+            "description": "Opaque token for the next page; null when there are no more results."
+          }
+        }
+      },
+      "AdvanceSettings": {
+        "type": "object",
+        "properties": {
+          "ruleClassId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Travel policy rule class ID"
+          },
+          "allowCarRentals": {
+            "type": "boolean",
+            "default": true
+          },
+          "allowHotelBookings": {
+            "type": "boolean",
+            "default": true
+          },
+          "meetingMatch": {
+            "$ref": "#/components/schemas/MeetingMatch"
+          },
+          "rulesEnforcement": {
+            "$ref": "#/components/schemas/RulesEnforcement"
+          }
+        }
+      },
+      "MeetingMatch": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable meeting match feature"
+          },
+          "matchingStartDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Meeting match window start (required if enabled)"
+          },
+          "matchingEndDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Meeting match window end (required if enabled)"
+          }
+        }
+      },
+      "RulesEnforcement": {
+        "type": "object",
+        "properties": {
+          "notifyManagerArrival": {
+            "$ref": "#/components/schemas/NotificationWindow"
+          },
+          "notifyManagerDeparture": {
+            "$ref": "#/components/schemas/NotificationWindow"
+          }
+        }
+      },
+      "NotificationWindow": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "startDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Discount": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "air",
+              "car",
+              "hotel",
+              "rail"
+            ],
+            "description": "Travel type the discount applies to"
+          },
+          "vendorCode": {
+            "type": "string",
+            "description": "Vendor IATA code (e.g., airline code, car rental company code)"
+          },
+          "discountCode": {
+            "type": "string"
+          },
+          "promoCode": {
+            "type": "string"
+          },
+          "validStartDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "validEndDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "discountType": {
+            "type": "string",
+            "enum": [
+              "percentage",
+              "fixed",
+              "corporate"
+            ]
+          },
+          "allowCodeShares": {
+            "type": "boolean",
+            "default": false
+          },
+          "saturdayNightRequired": {
+            "type": "boolean",
+            "default": false
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      },
+      "DiscountCreate": {
+        "type": "object",
+        "required": [
+          "type",
+          "vendorCode"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "air",
+              "car",
+              "hotel",
+              "rail"
+            ],
+            "description": "Travel type the discount applies to"
+          },
+          "vendorCode": {
+            "type": "string",
+            "description": "Vendor IATA code (e.g., airline code, car rental company code)"
+          },
+          "discountCode": {
+            "type": "string"
+          },
+          "promoCode": {
+            "type": "string"
+          },
+          "validStartDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "validEndDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "discountType": {
+            "type": "string",
+            "enum": [
+              "percentage",
+              "fixed",
+              "corporate"
+            ]
+          },
+          "allowCodeShares": {
+            "type": "boolean",
+            "default": false
+          },
+          "saturdayNightRequired": {
+            "type": "boolean",
+            "default": false
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      },
+      "Attendee": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "meetingId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "concurUuid": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Concur user profile UUID"
+          },
+          "concurLoginId": {
+            "type": "string",
+            "description": "Concur user login ID / email"
+          },
+          "profileType": {
+            "type": "string",
+            "enum": [
+              "employee",
+              "nonEmployee"
+            ]
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "bookingStatus": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "booked",
+              "cancelled"
+            ]
+          },
+          "tripId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "deepLink": {
+            "type": "string",
+            "format": "uri"
+          },
+          "partnerAttendeeId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Attendee ID in partner system (e.g., Cvent registrant ID)"
+          },
+          "createdOnUtc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastUpdatedOnUtc": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AttendeeCreate": {
+        "type": "object",
+        "required": [
+          "email",
+          "firstName",
+          "lastName",
+          "profileType"
+        ],
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "profileType": {
+            "type": "string",
+            "enum": [
+              "employee",
+              "nonEmployee"
+            ]
+          },
+          "concurUuid": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Concur user profile UUID (if known)"
+          },
+          "concurLoginId": {
+            "type": "string",
+            "description": "Concur user login ID / email (if known)"
+          },
+          "partnerAttendeeId": {
+            "type": "string",
+            "description": "Attendee ID in partner system (e.g., Cvent registrant ID)"
+          }
+        }
+      },
+      "AttendeeCreateResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Attendee"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "profileCreated": {
+                "type": "boolean",
+                "description": "Whether a new profile was created for this attendee"
+              }
+            }
+          }
+        ]
+      },
+      "AttendeeUpdate": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "partnerAttendeeId": {
+            "type": "string",
+            "description": "Updated partner attendee ID"
+          }
+        }
+      },
+      "BulkAttendeeResponse": {
+        "type": "object",
+        "properties": {
+          "totalRequested": {
+            "type": "integer"
+          },
+          "successful": {
+            "type": "integer"
+          },
+          "failed": {
+            "type": "integer"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "index": {
+                  "type": "integer"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "success",
+                    "error"
+                  ]
+                },
+                "attendee": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "email": {
+                          "type": "string",
+                          "format": "email"
+                        },
+                        "concurUuid": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "concurLoginId": {
+                          "type": "string"
+                        },
+                        "profileType": {
+                          "type": "string",
+                          "enum": [
+                            "employee",
+                            "nonEmployee"
+                          ]
+                        },
+                        "profileCreated": {
+                          "type": "boolean"
+                        },
+                        "deepLink": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "error": {
+                  "type": "object",
+                  "properties": {
+                    "errorCode": {
+                      "type": "string"
+                    },
+                    "errorMessage": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "LoginUrlResponse": {
+        "type": "object",
+        "properties": {
+          "loginUrl": {
+            "type": "string",
+            "description": "OTP login URL. Partner renders this as the \"Book Travel\" link.",
+            "example": "/oauth2/v0/otl_verify?otl=<otp>&targeturl=/travel/meetings/validate?meetingId=<uuid>&attendeeId=<uuid>"
+          },
+          "expiresInSeconds": {
+            "type": "integer",
+            "description": "Time in seconds before the OTP expires",
+            "example": 300
+          }
+        }
+      },
+      "Pagination": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "errorCode",
+                "errorMessage"
+              ],
+              "properties": {
+                "errorCode": {
+                  "type": "string",
+                  "enum": [
+                    "MEETING_NOT_FOUND",
+                    "ATTENDEE_NOT_FOUND",
+                    "MEETING_CANCELLED",
+                    "DUPLICATE_ATTENDEE",
+                    "PROFILE_NOT_FOUND",
+                    "EMPLOYEE_NOT_FOUND",
+                    "INVALID_DATE_RANGE",
+                    "UNAUTHORIZED",
+                    "FORBIDDEN",
+                    "VALIDATION_ERROR",
+                    "HAS_BOOKINGS",
+                    "NOT_MEETING_TRAVELER",
+                    "PARTNER_NOT_AUTHORIZED",
+                    "OTP_GENERATION_FAILED"
+                  ]
+                },
+                "errorMessage": {
+                  "type": "string"
+                },
+                "details": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Invalid or missing authentication",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "errors": [
+                {
+                  "errorCode": "UNAUTHORIZED",
+                  "errorMessage": "Invalid or missing authentication"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Insufficient permissions",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "errors": [
+                {
+                  "errorCode": "FORBIDDEN",
+                  "errorMessage": "Insufficient permissions"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "ValidationError": {
+        "description": "Request validation failed",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "errors": [
+                {
+                  "errorCode": "VALIDATION_ERROR",
+                  "errorMessage": "Request validation failed"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "MeetingNotFound": {
+        "description": "Meeting not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "errors": [
+                {
+                  "errorCode": "MEETING_NOT_FOUND",
+                  "errorMessage": "Meeting does not exist"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "AttendeeNotFound": {
+        "description": "Attendee not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "errors": [
+                {
+                  "errorCode": "ATTENDEE_NOT_FOUND",
+                  "errorMessage": "Attendee does not exist"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/api-explorer/v4-0/Meetings.oas3.json
+++ b/src/api-explorer/v4-0/Meetings.oas3.json
@@ -99,6 +99,15 @@
             "description": "Filter meetings starting before this date (ISO 8601)"
           },
           {
+            "name": "countAttendees",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "When true, each returned meeting includes an `attendeesCount` field. Adds one count query per meeting; off by default."
+          },
+          {
             "$ref": "#/components/parameters/Limit"
           },
           {
@@ -201,6 +210,17 @@
         "operationId": "getMeeting",
         "summary": "Get full meeting details (metadata + settings + discounts)",
         "description": "Retrieve all information about a specific meeting. For partial data, use the /metadata, /settings, or /discounts sub-resource endpoints.",
+        "parameters": [
+          {
+            "name": "countAttendees",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "When true, the returned meeting includes an `attendeesCount` field."
+          }
+        ],
         "responses": {
           "200": {
             "description": "Meeting details",
@@ -1015,6 +1035,56 @@
           }
         }
       }
+    },
+    "/companies/{companyId}/form-data": {
+      "parameters": [
+        {
+          "name": "companyId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "description": "Company UUID"
+        }
+      ],
+      "get": {
+        "security": [
+          {
+            "oauth2": [
+              "meetings.read"
+            ]
+          }
+        ],
+        "tags": [
+          "FormData"
+        ],
+        "operationId": "getCompanyFormData",
+        "summary": "Get company-level form data for meeting creation",
+        "description": "Retrieve the travel configs and their rule classes for a company. Used to populate\nthe travel-config and rule-class dropdowns when creating or editing a meeting.\nThe caller's JWT must belong to the same `companyId`.\n",
+        "responses": {
+          "200": {
+            "description": "Company form data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyFormDataResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1161,6 +1231,17 @@
           "updatedAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "attendeeCategories": {
+            "type": "array",
+            "description": "Attendee categories configured for this meeting.",
+            "items": {
+              "$ref": "#/components/schemas/AttendeeCategory"
+            }
+          },
+          "attendeesCount": {
+            "type": "integer",
+            "description": "Number of attendees on this meeting. Present only when the request set `countAttendees=true`."
           }
         }
       },
@@ -1239,6 +1320,13 @@
           "partnerMeetingId": {
             "type": "string",
             "description": "Meeting ID in partner system"
+          },
+          "attendeeCategories": {
+            "type": "array",
+            "description": "Attendee categories to configure for this meeting.",
+            "items": {
+              "$ref": "#/components/schemas/AttendeeCategoryWrite"
+            }
           }
         }
       },
@@ -1314,6 +1402,13 @@
               "concurLoginId": {
                 "type": "string"
               }
+            }
+          },
+          "attendeeCategories": {
+            "type": "array",
+            "description": "Replace the meeting's attendee categories.",
+            "items": {
+              "$ref": "#/components/schemas/AttendeeCategoryWrite"
             }
           }
         }
@@ -1411,6 +1506,13 @@
           "updatedAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "attendeeCategories": {
+            "type": "array",
+            "description": "Attendee categories configured for this meeting.",
+            "items": {
+              "$ref": "#/components/schemas/AttendeeCategory"
+            }
           }
         }
       },
@@ -1758,6 +1860,11 @@
           "lastUpdatedOnUtc": {
             "type": "string",
             "format": "date-time"
+          },
+          "attendeeCategory": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to the attendee category ID."
           }
         }
       },
@@ -1799,6 +1906,11 @@
           "partnerAttendeeId": {
             "type": "string",
             "description": "Attendee ID in partner system (e.g., Cvent registrant ID)"
+          },
+          "attendeeCategory": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to the attendee category ID."
           }
         }
       },
@@ -1986,6 +2098,106 @@
                 }
               }
             }
+          }
+        }
+      },
+      "AttendeeCategory": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Display name of the attendee category"
+          },
+          "ruleClass": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "travelConfig": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "fopConfig": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "AttendeeCategoryWrite": {
+        "type": "object",
+        "required": [
+          "displayName",
+          "ruleClass",
+          "travelConfig",
+          "fopConfig"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Present for updates; omit to create a new category."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Display name of the attendee category."
+          },
+          "ruleClass": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "travelConfig": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "fopConfig": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "CompanyFormDataResponse": {
+        "type": "object",
+        "properties": {
+          "travelConfigs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TravelConfigResponse"
+            }
+          }
+        }
+      },
+      "TravelConfigResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Travel config UUID"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name of the travel config"
+          },
+          "ruleClasses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RuleClass"
+            }
+          }
+        }
+      },
+      "RuleClass": {
+        "type": "object",
+        "properties": {
+          "ruleClassUuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ruleClassName": {
+            "type": "string"
           }
         }
       }

--- a/src/api-guides/meetings/meetings-integration-guide.markdown
+++ b/src/api-guides/meetings/meetings-integration-guide.markdown
@@ -1,0 +1,75 @@
+---
+title: Meetings - Third-Party Meetings Integration Guide
+layout: reference
+---
+
+
+# Meetings - Third-Party Meetings Integration Guide
+
+This guide describes how third-party meeting partners (for example, event and meeting-management providers) integrate with the SAP Concur **Meetings API** to create and manage meetings and their attendees. It assumes you are familiar with the SAP Concur Platform, that you have registered your application, and that you know how to obtain an OAuth bearer token and call SAP Concur APIs.
+
+## APIs Used in This Guide
+
+`Base URL: https://us.api.concursolutions.com/meetings/v4` (US) / `https://emea.api.concursolutions.com/meetings/v4` (EMEA)
+
+* `/meetings`
+* `/meetings/{meetingId}`
+* `/meetings/{meetingId}/attendees`
+* `/meetings/{meetingId}/attendees/bulk`
+* `/meetings/{meetingId}/attendees/{attendeeId}`
+
+See the [Meetings API reference](/api-explorer/v4-0/Meetings.html) for the full list of operations, request/response schemas, and error codes.
+
+## Authentication and Scopes
+
+All requests require an OAuth 2.0 bearer token in the `Authorization: Bearer <token>` header. Partners obtain the token via the OAuth password grant, consistent with other enterprise applications.
+
+The API uses per-operation scopes:
+
+* `meetings.read` — read meetings and attendees (GET operations)
+* `meetings.write` — create, update, and delete meetings and attendees (POST, PATCH, DELETE operations)
+
+## Tenant Scoping with `companyId`
+
+Meeting-scoped operations accept an optional `companyId` query parameter. When omitted, the company is resolved from the token's company claim. When supplied, it must match the token's company; a mismatch returns `403`. Supplying a well-formed `companyId` that the token is entitled to is recommended for clarity.
+
+## Workflow
+
+### 1. Create a meeting
+
+`POST /meetings`
+
+Creates a meeting in the caller's company. The response includes the generated `meetingId` used for all subsequent operations.
+
+### 2. Add attendees
+
+Add attendees one at a time with `POST /meetings/{meetingId}/attendees`, or in a single call with the bulk endpoint:
+
+`POST /meetings/{meetingId}/attendees/bulk`
+
+The bulk endpoint accepts a JSON body of the form `{ "attendees": [ ... ] }` and returns **`207 Multi-Status`**, with a per-item status so you can tell which attendees succeeded and which failed. An empty or missing `attendees` array returns `400`.
+
+### 3. Read and update
+
+* `GET /meetings/{meetingId}` — retrieve a meeting
+* `GET /meetings/{meetingId}/attendees` — list attendees
+* `PATCH /meetings/{meetingId}` and `PATCH /meetings/{meetingId}/attendees/{attendeeId}` — apply partial updates using JSON Merge Patch (`application/merge-patch+json`)
+
+### 4. Remove
+
+* `DELETE /meetings/{meetingId}/attendees/{attendeeId}` — remove an attendee
+* `DELETE /meetings/{meetingId}` — delete the meeting
+
+## Error Handling
+
+Errors are returned using the standard SAP Concur error envelope:
+
+```json
+{
+  "errors": [
+    { "errorCode": "ATTENDEE_NOT_FOUND", "errorMessage": "Attendee does not exist: <id>" }
+  ]
+}
+```
+
+Handle the `errorCode` field programmatically; `errorMessage` is intended for logging and diagnostics.

--- a/src/api-reference/travel/v4.meetings-endpoints.markdown
+++ b/src/api-reference/travel/v4.meetings-endpoints.markdown
@@ -1,0 +1,243 @@
+---
+title: Meetings v4 Endpoints
+layout: reference
+---
+
+{% include prerelease.html %}
+
+This page documents the endpoints, payloads, and schemas for the Meetings API v4. See [Meetings v4](/api-reference/travel/v4.meetings-get-started.html) for the overview, scopes, authentication, and base URIs.
+
+All meeting-scoped endpoints accept an optional `companyId` query parameter (UUID). When omitted, the company is resolved from the token; when supplied it must match the token's company.
+
+## <a name="list-meetings"></a>List Meetings
+
+Retrieves meetings for the caller's company.
+
+### Scopes
+
+`meetings.read` — Refer to [Scope Usage](/api-reference/travel/v4.meetings-get-started.html#scope-usage).
+
+### URI
+
+```shell
+GET https://{datacenterURI}/meetings/v4/meetings?companyId={companyId}
+```
+
+### Parameters
+
+Name|Type|Format|Description
+---|---|---|---
+`companyId`|`string`|`uuid`|Company identifier. Optional; must match the token's company when supplied.
+`limit`|`integer`|-|Maximum number of results per page.
+`offset`|`integer`|-|Number of results to skip for pagination.
+
+### Examples
+
+#### Request
+
+```shell
+GET https://us.api.concursolutions.com/meetings/v4/meetings?companyId=62ec4e74-3238-41a2-9233-c1cc901c2daa
+Accept: application/json
+Authorization: Bearer {token}
+```
+
+#### Response
+
+```shell
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "meetings": [
+    {
+      "id": "5036ada6-25e8-4e96-9d28-59788b1cdd67",
+      "name": "Q3 Sales Kickoff",
+      "status": "active",
+      "locationName": "Grand Hotel",
+      "airport": "SFO",
+      "startDateTime": "2026-09-01T09:00:00Z",
+      "endDateTime": "2026-09-03T17:00:00Z",
+      "timeZone": "America/Los_Angeles"
+    }
+  ],
+  "pagination": { "limit": 25, "offset": 0, "total": 1 }
+}
+```
+
+## <a name="create-meeting"></a>Create Meeting
+
+Creates a meeting in the caller's company. The response includes the generated `id`.
+
+### Scopes
+
+`meetings.write`
+
+### URI
+
+```shell
+POST https://{datacenterURI}/meetings/v4/meetings
+```
+
+### Payloads
+
+* Request: [MeetingCreate](#schema-meetingcreate)
+* Response: Meeting id and status
+
+### Examples
+
+#### Request
+
+```shell
+POST https://us.api.concursolutions.com/meetings/v4/meetings
+Content-Type: application/json
+Authorization: Bearer {token}
+```
+
+```json
+{
+  "companyId": "62ec4e74-3238-41a2-9233-c1cc901c2daa",
+  "name": "Q3 Sales Kickoff",
+  "locationName": "Grand Hotel",
+  "airport": "SFO",
+  "startDateTime": "2026-09-01T09:00:00Z",
+  "endDateTime": "2026-09-03T17:00:00Z",
+  "timeZone": "America/Los_Angeles",
+  "travelConfigId": "0b2f...",
+  "partnerMeetingId": "CVENT-12345"
+}
+```
+
+#### Response
+
+```shell
+HTTP/1.1 201 Created
+Content-Type: application/json
+```
+
+```json
+{ "id": "5036ada6-25e8-4e96-9d28-59788b1cdd67", "status": "active" }
+```
+
+## <a name="get-meeting"></a>Get, Update, and Delete a Meeting
+
+* `GET /meetings/{meetingId}` (`meetings.read`) — full meeting details (metadata + settings + discounts).
+* `PATCH /meetings/{meetingId}` (`meetings.write`) — partial update using JSON Merge Patch (`Content-Type: application/merge-patch+json`).
+* `DELETE /meetings/{meetingId}` (`meetings.write`) — soft-delete the meeting.
+
+Related read-only sub-resources: `GET /meetings/{meetingId}/metadata`, `/settings`, `/discounts`, and `/history`.
+
+### PATCH Example
+
+```shell
+PATCH https://us.api.concursolutions.com/meetings/v4/meetings/5036ada6-25e8-4e96-9d28-59788b1cdd67
+Content-Type: application/merge-patch+json
+Authorization: Bearer {token}
+```
+
+```json
+{ "name": "Q3 Sales Kickoff (Updated)" }
+```
+
+## <a name="attendees"></a>Attendees
+
+* `GET /meetings/{meetingId}/attendees` (`meetings.read`) — list attendees.
+* `POST /meetings/{meetingId}/attendees` (`meetings.write`) — add a single attendee.
+* `POST /meetings/{meetingId}/attendees/bulk` (`meetings.write`) — add multiple attendees; returns **`207 Multi-Status`** with per-item results.
+* `GET /meetings/{meetingId}/attendees/{attendeeId}` (`meetings.read`) — get an attendee.
+* `PATCH /meetings/{meetingId}/attendees/{attendeeId}` (`meetings.write`) — partial update (JSON Merge Patch).
+* `DELETE /meetings/{meetingId}/attendees/{attendeeId}` (`meetings.write`) — remove an attendee.
+* `POST /meetings/{meetingId}/attendees/{attendeeId}/login-url` (`meetings.write`) — generate a one-time login URL for a non-employee attendee.
+
+### Bulk Add Example
+
+The bulk endpoint takes a JSON body with an `attendees` array. An empty or missing array returns `400`.
+
+#### Request
+
+```shell
+POST https://us.api.concursolutions.com/meetings/v4/meetings/{meetingId}/attendees/bulk
+Content-Type: application/json
+Authorization: Bearer {token}
+```
+
+```json
+{
+  "attendees": [
+    { "email": "jane@example.com", "firstName": "Jane", "lastName": "Doe", "profileType": "nonEmployee" },
+    { "email": "john@example.com", "firstName": "John", "lastName": "Roe", "profileType": "employee" }
+  ]
+}
+```
+
+#### Response
+
+```shell
+HTTP/1.1 207 Multi-Status
+Content-Type: application/json
+```
+
+```json
+{
+  "totalRequested": 2,
+  "successful": 2,
+  "failed": 0,
+  "results": [
+    { "index": 0, "status": 201, "id": "17eeba90-d260-4bf6-8814-7f6336acf0e4" },
+    { "index": 1, "status": 201, "id": "820a1325-d80c-4d80-adfa-ae6b322bc009" }
+  ]
+}
+```
+
+## <a name="schema"></a>Schema
+
+### <a name="schema-meetingcreate"></a>MeetingCreate
+
+Name|Type|Format|Description
+---|---|---|---
+`companyId`|`string`|`uuid`|**Required** Company that owns the meeting.
+`name`|`string`|-|**Required** Meeting name.
+`description`|`string`|-|Meeting description.
+`locationName`|`string`|-|**Required** Location name.
+`airport`|`string`|-|**Required** Nearest airport IATA code.
+`startDateTime`|`string`|`date-time`|**Required** Meeting start (ISO 8601).
+`endDateTime`|`string`|`date-time`|**Required** Meeting end (ISO 8601).
+`timeZone`|`string`|-|**Required** IANA time zone (e.g., `America/Los_Angeles`).
+`travelConfigId`|`string`|`uuid`|**Required** Travel configuration identifier.
+`billingCode`|`string`|-|Billing code.
+`partnerMeetingId`|`string`|-|Meeting ID in the partner system (e.g., Cvent event ID).
+
+### <a name="schema-attendeecreate"></a>AttendeeCreate
+
+Name|Type|Format|Description
+---|---|---|---
+`email`|`string`|`email`|**Required** Attendee email.
+`firstName`|`string`|-|**Required** Attendee first name.
+`lastName`|`string`|-|**Required** Attendee last name.
+`profileType`|`string`|`enum`|**Required** One of `employee`, `nonEmployee`.
+`concurUuid`|`string`|`uuid`|Concur user profile UUID, if known.
+`concurLoginId`|`string`|-|Concur login ID / email, if known.
+`partnerAttendeeId`|`string`|-|Attendee ID in the partner system.
+
+### <a name="schema-attendee"></a>Attendee
+
+Name|Type|Format|Description
+---|---|---|---
+`id`|`string`|`uuid`|Attendee identifier.
+`meetingId`|`string`|`uuid`|Parent meeting identifier.
+`profileType`|`string`|`enum`|One of `employee`, `nonEmployee`.
+`email`|`string`|`email`|Attendee email.
+`firstName`|`string`|-|Attendee first name.
+`lastName`|`string`|-|Attendee last name.
+`bookingStatus`|`string`|`enum`|One of `pending`, `booked`, `cancelled`.
+`tripId`|`string`|`uuid`|Associated trip identifier, if booked.
+`partnerAttendeeId`|`string`|-|Attendee ID in the partner system.
+
+### <a name="schema-error"></a>Error
+
+Name|Type|Format|Description
+---|---|---|---
+`errors`|`array`|[`error`](#schema-error)|**Required** Array of error objects.
+`errorCode`|`string`|-|**Required** Machine-readable, non-localized code (e.g., `ATTENDEE_NOT_FOUND`, `VALIDATION_ERROR`, `FORBIDDEN`).
+`errorMessage`|`string`|-|**Required** Human-readable message for logging and diagnostics.

--- a/src/api-reference/travel/v4.meetings-endpoints.markdown
+++ b/src/api-reference/travel/v4.meetings-endpoints.markdown
@@ -28,6 +28,7 @@ GET https://{datacenterURI}/meetings/v4/meetings?companyId={companyId}
 Name|Type|Format|Description
 ---|---|---|---
 `companyId`|`string`|`uuid`|Company identifier. Optional; must match the token's company when supplied.
+`countAttendees`|`boolean`|-|When `true`, each returned meeting includes an `attendeesCount` field. Off by default.
 `limit`|`integer`|-|Maximum number of results per page.
 `offset`|`integer`|-|Number of results to skip for pagination.
 
@@ -186,6 +187,26 @@ Content-Type: application/json
   "results": [
     { "index": 0, "status": 201, "id": "17eeba90-d260-4bf6-8814-7f6336acf0e4" },
     { "index": 1, "status": 201, "id": "820a1325-d80c-4d80-adfa-ae6b322bc009" }
+  ]
+}
+```
+
+## <a name="form-data"></a>Company Form Data
+
+`GET /companies/{companyId}/form-data` (`meetings.read`) — retrieves the travel configs and their rule classes for a company, used to populate the travel-config and rule-class options when creating or editing a meeting. The caller's token must belong to the same company.
+
+### Example
+
+```shell
+GET https://us.api.concursolutions.com/meetings/v4/companies/62ec4e74-3238-41a2-9233-c1cc901c2daa/form-data
+Accept: application/json
+Authorization: Bearer {token}
+```
+
+```json
+{
+  "travelConfigs": [
+    { "id": "0b2f...", "name": "Default Travel Config", "ruleClasses": [ { "ruleClassUuid": "...", "ruleClassName": "Default" } ] }
   ]
 }
 ```

--- a/src/api-reference/travel/v4.meetings-get-started.markdown
+++ b/src/api-reference/travel/v4.meetings-get-started.markdown
@@ -1,0 +1,63 @@
+---
+title: Meetings v4
+layout: reference
+---
+
+{% include prerelease.html %}
+
+The Meetings API lets you create and manage meetings and their attendees within SAP Concur. It supports two primary use cases: **Concur Meetings** created directly within Concur (via the Meetings Admin UI or Joule), and **Third-Party Meetings** created by external partners (for example, Cvent) through API integration.
+
+## <a name="limitations"></a>Limitations
+
+* Access to this documentation does not provide access to the API. Partner applications must be registered and granted the appropriate scopes.
+* This is the partner-facing edition of the API. Internal-only operations are not exposed.
+* The API is versioned at `v4`. Breaking changes will be delivered in a new version.
+
+## <a name="process-flow"></a>Process Flow
+
+The most common partner flow is: create a meeting, add its attendees (individually or in bulk), then read or update the meeting and attendees as needed.
+
+>insert sample diagram here
+
+## <a name="products-editions"></a>Products and Editions
+
+* Concur Travel Professional Edition
+* Concur Travel Standard Edition
+
+## <a name="scope-usage"></a>Scope Usage
+
+Name|Description|Endpoint
+---|---|---
+`meetings.read`|Read meetings, attendees, and history|All `GET` endpoints
+`meetings.write`|Create, update, and delete meetings, attendees, and login URLs|All `POST`, `PATCH`, and `DELETE` endpoints
+
+## <a name="dependencies"></a>Dependencies
+
+* **OAuth 2.0 token endpoint** — required to obtain the bearer token used on every request. Partners obtain a User JWT via the OAuth password grant, consistent with other enterprise applications.
+
+## <a name="access-token-usage"></a>Access Token Usage
+
+All requests require an OAuth 2.0 bearer token in the `Authorization: Bearer <token>` header. The API accepts a **User JWT** or **Company JWT**; the company is resolved from the token's company claim.
+
+Meeting-scoped endpoints also accept an optional `companyId` query parameter. When omitted, the company is resolved from the token. When supplied, it **must** match the token's company — a mismatch returns `403`, and a malformed value returns `400`.
+
+## <a name="base-uris"></a>Base URIs
+
+* US Production: `https://us.api.concursolutions.com/meetings/v4`
+* EMEA Production: `https://emea.api.concursolutions.com/meetings/v4`
+
+Refer to [Base URIs](/platform/base-uris.html) for details on selecting the correct instance URL.
+
+## <a name="errors"></a>Error Handling
+
+Errors are returned using the standard SAP Concur error envelope. Handle `errorCode` programmatically; `errorMessage` is intended for logging.
+
+```json
+{
+  "errors": [
+    { "errorCode": "ATTENDEE_NOT_FOUND", "errorMessage": "Attendee does not exist: <id>" }
+  ]
+}
+```
+
+See the [Meetings v4 Endpoints](/api-reference/travel/v4.meetings-endpoints.html) page for the full list of operations, payloads, and schemas.

--- a/src/api-reference/travel/v4.meetings-get-started.markdown
+++ b/src/api-reference/travel/v4.meetings-get-started.markdown
@@ -15,9 +15,31 @@ The Meetings API lets you create and manage meetings and their attendees within 
 
 ## <a name="process-flow"></a>Process Flow
 
-The most common partner flow is: create a meeting, add its attendees (individually or in bulk), then read or update the meeting and attendees as needed.
+The most common partner flow is: obtain an access token, create a meeting, add its attendees (individually or in bulk), then read or update the meeting and attendees as needed. Removing attendees and deleting the meeting are optional end-of-lifecycle steps.
 
->insert sample diagram here
+> **Note to tech writers:** basic flow below (Mermaid). Please restyle to the dev-portal diagram standard.
+
+```mermaid
+flowchart TD
+    A([Start]) --> B[Obtain OAuth 2.0 token<br/>password grant → Bearer JWT<br/><i>prerequisite: OAuth token endpoint</i>]
+    B --> C[POST /meetings<br/>scope: meetings.write<br/>→ returns meetingId]
+    C --> D{Add attendees}
+    D -->|one| E[POST /meetings/&#123;meetingId&#125;/attendees<br/>scope: meetings.write]
+    D -->|many| F[POST /meetings/&#123;meetingId&#125;/attendees/bulk<br/>scope: meetings.write → 207 Multi-Status]
+    E --> G[GET meeting / attendees<br/>scope: meetings.read]
+    F --> G
+    G --> H{Updates needed?}
+    H -->|yes| I[PATCH meeting / attendee<br/>merge-patch+json · scope: meetings.write]
+    I --> G
+    H -->|no| J{End of lifecycle?}
+    J -->|remove attendee| K[DELETE /meetings/&#123;meetingId&#125;/attendees/&#123;attendeeId&#125;]
+    J -->|delete meeting| L[DELETE /meetings/&#123;meetingId&#125;<br/>soft delete]
+    K --> M([End])
+    L --> M
+    J -->|no| M
+```
+
+**Prerequisite calls (other APIs):** the OAuth 2.0 token endpoint is required before any Meetings API call to obtain the Bearer token. No other cross-API prerequisites are required for the core flow.
 
 ## <a name="products-editions"></a>Products and Editions
 

--- a/src/api-reference/travel/v4.meetings-get-started.markdown
+++ b/src/api-reference/travel/v4.meetings-get-started.markdown
@@ -21,19 +21,19 @@ The most common partner flow is: obtain an access token, create a meeting, add i
 
 ```mermaid
 flowchart TD
-    A([Start]) --> B[Obtain OAuth 2.0 token<br/>password grant → Bearer JWT<br/><i>prerequisite: OAuth token endpoint</i>]
-    B --> C[POST /meetings<br/>scope: meetings.write<br/>→ returns meetingId]
-    C --> D{Add attendees}
-    D -->|one| E[POST /meetings/&#123;meetingId&#125;/attendees<br/>scope: meetings.write]
-    D -->|many| F[POST /meetings/&#123;meetingId&#125;/attendees/bulk<br/>scope: meetings.write → 207 Multi-Status]
-    E --> G[GET meeting / attendees<br/>scope: meetings.read]
+    A([Start]) --> B["Obtain OAuth 2.0 token (password grant, Bearer JWT) — prerequisite: OAuth token endpoint"]
+    B --> C["POST /meetings — scope meetings.write, returns meetingId"]
+    C --> D{"Add attendees"}
+    D -->|one| E["POST /meetings/:meetingId/attendees — scope meetings.write"]
+    D -->|many| F["POST /meetings/:meetingId/attendees/bulk — scope meetings.write, 207 Multi-Status"]
+    E --> G["GET meeting / attendees — scope meetings.read"]
     F --> G
-    G --> H{Updates needed?}
-    H -->|yes| I[PATCH meeting / attendee<br/>merge-patch+json · scope: meetings.write]
+    G --> H{"Updates needed?"}
+    H -->|yes| I["PATCH meeting / attendee — merge-patch+json, scope meetings.write"]
     I --> G
-    H -->|no| J{End of lifecycle?}
-    J -->|remove attendee| K[DELETE /meetings/&#123;meetingId&#125;/attendees/&#123;attendeeId&#125;]
-    J -->|delete meeting| L[DELETE /meetings/&#123;meetingId&#125;<br/>soft delete]
+    H -->|no| J{"End of lifecycle?"}
+    J -->|remove attendee| K["DELETE /meetings/:meetingId/attendees/:attendeeId"]
+    J -->|delete meeting| L["DELETE /meetings/:meetingId — soft delete"]
     K --> M([End])
     L --> M
     J -->|no| M


### PR DESCRIPTION
## Add Meetings API v4 to the Dev Center

Adds developer documentation for the **Concur Meetings API (v4)** — API reference (Swagger API Explorer) and an integration guide.

Tracked by **MEET-698** (Add Meetings API to developer.concur.com). API Success / Launch Review: **ARCH-2972**.

### Changes

- **`src/api-explorer/v4-0/Meetings.oas3.json`** — partner-facing OpenAPI 3.0.3 spec for the Meetings API (internal-only operations excluded).
- **`src/api-explorer/v4-0/Meetings.markdown`** — reference page rendering the spec via the `{% swagger %}` include (mirrors `Cards.markdown`).
- **`src/_data/sidebars/api-explorer.yml`** — adds a **Meetings** entry to the v4.0 section.
- **`src/api-guides/meetings/meetings-integration-guide.markdown`** — new *Third-Party Meetings Integration Guide* covering auth/scopes, `companyId` tenant scoping, the create → add attendees (incl. bulk `207`) → read/update (`PATCH`) → delete workflow, and the standard `errors[]` envelope.
- **`src/_data/sidebars/api-guides.yml`** — adds a **Meetings** guide section.

### Notes

- *Opened for early review ahead of GA (Launch Checklist item 5, "submit Markdown/API reference to Dev Center Team ≥30 days prior to GA"). Content will be finalized with the Dev Center team.
- The v4.0 explorer sidebar entry currently points to the local page (`/api-explorer/v4-0/Meetings.html`); it can be switched to the SAP Business Accelerator Hub URL once the API is published there from the swagger repo.
- Content is derived from the partner-facing API surface only (public endpoints, scopes, error shapes) — no internal-only operations.
