### PR TITLE
docs(meetings): promote Meetings v4 from preview to now available

### DIFF
--- a/src/api-explorer/v4-0/Meetings.markdown
+++ b/src/api-explorer/v4-0/Meetings.markdown
@@ -3,5 +3,4 @@ title: Meetings
 layout: reference
 reference-type: swagger
 ---
-{% include prerelease.html %} 
 {% swagger /api-explorer/v4-0/Meetings.oas3.json %}

--- a/src/api-explorer/v4-0/Meetings.oas3.json
+++ b/src/api-explorer/v4-0/Meetings.oas3.json
@@ -1,11 +1,15 @@
 {
   "openapi": "3.0.3",
-  "x-sap-shortText": "Manage Concur meetings and their attendees, including third-party partner meeting integration",
+  "x-sap-shortText": "Manages meetings and attendees within Concur Travel, including partner integrations",
   "info": {
-    "title": "Concur Meetings API",
+    "title": "Meetings",
     "version": "v4",
-    "description": "API for managing meetings and attendees within SAP Concur.\n\nSupports two primary use cases:\n1. **Concur Meetings** – Meetings created directly within Concur via Meetings Admin UI or Joule\n2. **Third-Party Meetings** – Meetings created by external partners (e.g., Cvent) via API integration\n\nThis is the partner-facing edition of the spec. Internal-only operations are not included.\n",
+    "description": "Creates and manages meetings and attendees within Concur Travel. Supports meetings initiated natively within the SAP Concur platform and meetings created by external partners through API integration, where the API keeps both systems synchronized. Includes attendee management with sponsored guest support, travel discount attachment, meeting-to-booking matching, and audit history.",
     "termsOfService": "https://developer.concur.com/Terms-of-Use.html"
+  },
+  "externalDocs": {
+    "description": "API Reference",
+    "url": "https://developer.concur.com/api-reference/travel/meetings-v4/v4.meetings-get-started.html"
   },
   "servers": [
     {

--- a/src/api-guides/meetings/meetings-integration-guide.markdown
+++ b/src/api-guides/meetings/meetings-integration-guide.markdown
@@ -20,7 +20,7 @@ This guide describes how third-party meeting partners, such as event and meeting
 * `/meetings/{meetingId}/attendees/bulk`
 * `/meetings/{meetingId}/attendees/{attendeeId}`
 
-See the [Meetings API reference](https://developer.concur.com/api-reference/travel/meetings-v4/v4.meetings-get-started.html) for the full list of operations, request/response schemas, and error codes.
+See the [Meetings API reference](/api-reference/travel/meetings-v4/v4.meetings-get-started.html) for the full list of operations, request/response schemas, and error codes.
 
 ## Authentication and Scopes
 

--- a/src/api-guides/meetings/meetings-integration-guide.markdown
+++ b/src/api-guides/meetings/meetings-integration-guide.markdown
@@ -6,9 +6,11 @@ layout: reference
 
 # Meetings - Third-Party Meetings Integration Guide
 
-This guide describes how third-party meeting partners (for example, event and meeting-management providers) integrate with the SAP Concur **Meetings API** to create and manage meetings and their attendees. It assumes you are familiar with the SAP Concur Platform, that you have registered your application, and that you know how to obtain an OAuth bearer token and call SAP Concur APIs.
+This guide describes how third-party meeting partners, such as event and meeting-management providers, integrate with the SAP Concur Meetings API to create and manage meetings and their attendees.
 
-## APIs Used in This Guide
+**Note:** You must have a registered application on App Center and a valid OAuth 2.0 bearer token.
+
+## APIs Used in this Guide
 
 `Base URL: https://us.api.concursolutions.com/meetings/v4` (US) / `https://emea.api.concursolutions.com/meetings/v4` (EMEA)
 
@@ -18,7 +20,7 @@ This guide describes how third-party meeting partners (for example, event and me
 * `/meetings/{meetingId}/attendees/bulk`
 * `/meetings/{meetingId}/attendees/{attendeeId}`
 
-See the [Meetings API reference](/api-explorer/v4-0/Meetings.html) for the full list of operations, request/response schemas, and error codes.
+See the [Meetings API reference](https://developer.concur.com/api-reference/travel/meetings-v4/v4.meetings-get-started.html) for the full list of operations, request/response schemas, and error codes.
 
 ## Authentication and Scopes
 

--- a/src/api-reference/authentication/app-center-learn-more.markdown
+++ b/src/api-reference/authentication/app-center-learn-more.markdown
@@ -79,6 +79,8 @@ Scope|User Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbs
 `locate.location.read` <a name="locate-location-read"></a> |Allows the application to only view the SAP  Concur Locate user location|[User Location v4](/api-reference/locate/v4.userLocations.html)
 `locate.location.write` <a name="locate-location-write"></a> |Allows the application to write user location information using SAP Concur Locate API service|[User Location v4](/api-reference/locate/v4.userLocations.html)
 `MEDIC` <a name="medic"></a> |Medical alerts|[Travel Profile v2 Medical Alerts](/api-reference/travel-profile/v2.profile-resource.html#General)
+`meetings.read` <a name="meetings-read"></a> |Read meetings, attendees, and history|[Meetings v4](/api-reference/travel/meetings-v4/v4.meetings-get-started.html)
+`meetings.write` <a name="meetings-write"></a> |Create, update, and delete meetings, attendees, and login URLs|[Meetings v4](/api-reference/travel/meetings-v4/v4.meetings-get-started.html)
 `NOTIF` <a name="notif"></a> |Receive notifications when expense reports change|[Event Notification Callout](/api-reference/callouts/event-notification.html), [Get Notification](/api-reference/callouts/get-notifications-status.html), [Delete Notification](/api-reference/callouts/delete-notification.html), [Post Notification](/api-reference/callouts/post-event-notification.html)
 `PASSV` <a name="passv"></a> |Passport visa information|[Travel Profile v2 Passport](/api-reference/travel-profile/v2.profile-resource.html#Passports), [Travel Profile v2 Visa](/api-reference/travel-profile/v2.profile-resource.html#Visas)
 `PAYBAT` <a name="paybat"></a> |Close and export payment batches|[Payment Batches v1.1](/api-reference/expense/payment-batch/v1.payment-batches.html)

--- a/src/api-reference/travel/meetings-v4/v4.meetings-endpoints.markdown
+++ b/src/api-reference/travel/meetings-v4/v4.meetings-endpoints.markdown
@@ -3,9 +3,13 @@ title: Meetings v4 - Endpoints
 layout: reference
 ---
 
+# Meetings v4 - Endpoints
+
 Endpoints and schemas for creating and managing meetings and attendees within the SAP Concur platform.
 
 All meeting-scoped endpoints accept an optional `companyId` query parameter (UUID). When omitted, the company is resolved from the token; when supplied it must match the token's company.
+
+Find integration details in the [Meetings Integration Guide](/api-guides/meetings/meetings-integration-guide.html).
 
 ## <a name="list-meetings"></a>List Meetings
 

--- a/src/api-reference/travel/meetings-v4/v4.meetings-get-started.markdown
+++ b/src/api-reference/travel/meetings-v4/v4.meetings-get-started.markdown
@@ -3,13 +3,15 @@ title: Meetings v4
 layout: reference
 ---
 
+# Meetings v4
+
 With the Meetings API, you can create and manage meetings and their attendees within Concur Travel. It supports two primary use cases: meetings created natively within the SAP Concur platform using the Meetings Admin UI or Joule, and meetings created by external partners through API integration.
 
 ## <a name="limitations"></a>Limitations
 
 Access to this documentation does not provide access to the API.
 
-Access to this API requires registration as a partner and approval of the appropriate scopes. Please contact your SAP Concur representative for more information.
+Partner registration and scope approval are required. Please contact your SAP Concur representative for more information.
 
 ## <a name="process-flow"></a>Process Flow
 

--- a/src/tools-support/release-notes/api/2026-06-03.md
+++ b/src/tools-support/release-notes/api/2026-06-03.md
@@ -12,7 +12,7 @@ With the Legal Entity v4.1 API, customers and partners can manage legal entity p
 
 ### Preview: Meetings API
 
-The Meetings API will provide customers and partners with a seamless way to create, manage, and integrate meetings within SAP Concur. It supports meetings created directly within Concur via the Meetings Admin UI, as well as third-party meetings originating from a partner's platform — where the API keeps both systems in sync.
+The Meetings API will enable customers and partners to create, manage, and integrate meetings within the SAP Concur platform. It supports meetings created directly within Concur Travel via the Meetings Admin UI, as well as meetings originating from a partner's platform — where the API keeps both systems in sync.
 
 **Key capabilities**
 

--- a/src/tools-support/release-notes/api/2026-06-03.md
+++ b/src/tools-support/release-notes/api/2026-06-03.md
@@ -12,7 +12,7 @@ With the Legal Entity v4.1 API, customers and partners can manage legal entity p
 
 ### Preview: Meetings API
 
-The Meetings API will enable customers and partners to create, manage, and integrate meetings within the SAP Concur platform. It supports meetings created directly within Concur Travel via the Meetings Admin UI, as well as meetings originating from a partner's platform — where the API keeps both systems in sync.
+The Meetings API will enable customers and partners to create, manage, and integrate meetings within the SAP Concur platform. It supports meetings created directly within Concur Travel via the Meetings Admin UI, as well as third-party meetings originating from a partner's platform — where the API keeps both systems in sync.
 
 **Key capabilities**
 

--- a/src/tools-support/release-notes/api/2026-06-03.md
+++ b/src/tools-support/release-notes/api/2026-06-03.md
@@ -32,7 +32,7 @@ The Meetings API will provide customers and partners with a seamless way to crea
 
 **Configuration / Feature Activation**
 
-The Meetings API will be available to third-party partners using Company-level OAuth 2.0 JWT tokens with `meetings.read` and `meetings.write` scopes.
+The Meetings API will be available to partners using Company-level OAuth 2.0 JWT tokens with `meetings.read` and `meetings.write` scopes.
 
 ### Deprecation: Company Cards Transactions v1 API
  

--- a/src/tools-support/release-notes/api/2026-08-06.md
+++ b/src/tools-support/release-notes/api/2026-08-06.md
@@ -8,7 +8,7 @@ layout: reference
 
 ### Now Available: Meetings API
 
-The Meetings API provides customers and partners with a seamless way to create, manage, and integrate meetings within SAP Concur. It supports meetings created directly within Concur via the Meetings Admin UI, as well as third-party meetings originating from a partner's platform — where the API keeps both systems in sync.
+The Meetings API enables customers and partners to create, manage, and integrate meetings within the SAP Concur platform. It supports meetings created directly within Concur Travel via the Meetings Admin UI, as well as meetings originating from a partner's platform — where the API keeps both systems in sync.
 
 **Key capabilities**
 

--- a/src/tools-support/release-notes/api/2026-08-06.md
+++ b/src/tools-support/release-notes/api/2026-08-06.md
@@ -28,7 +28,7 @@ The Meetings API provides customers and partners with a seamless way to create, 
 
 **Configuration / Feature Activation**
 
-The Meetings API is available to third-party partners using Company-level OAuth 2.0 JWT tokens with `meetings.read` and `meetings.write` scopes.
+The Meetings API is available to partners using Company-level OAuth 2.0 JWT tokens with `meetings.read` and `meetings.write` scopes.
 
 ### Preview: Detokenizer v5 – Get Banking Info API
 

--- a/src/tools-support/release-notes/api/2026-08-06.md
+++ b/src/tools-support/release-notes/api/2026-08-06.md
@@ -8,7 +8,7 @@ layout: reference
 
 ### Now Available: Meetings API
 
-The Meetings API enables customers and partners to create, manage, and integrate meetings within the SAP Concur platform. It supports meetings created directly within Concur Travel via the Meetings Admin UI, as well as meetings originating from a partner's platform — where the API keeps both systems in sync.
+The Meetings API enables customers and partners to create, manage, and integrate meetings within the SAP Concur platform. It supports meetings created directly within Concur Travel via the Meetings Admin UI, as well as third-party meetings originating from a partner's platform — where the API keeps both systems in sync.
 
 **Key capabilities**
 

--- a/src/tools-support/release-notes/api/2026-08-06.md
+++ b/src/tools-support/release-notes/api/2026-08-06.md
@@ -6,6 +6,30 @@ layout: reference
 
 ## New This Month
 
+### Now Available: Meetings API
+
+The Meetings API provides customers and partners with a seamless way to create, manage, and integrate meetings within SAP Concur. It supports meetings created directly within Concur via the Meetings Admin UI, as well as third-party meetings originating from a partner's platform — where the API keeps both systems in sync.
+
+**Key capabilities**
+
+* Meeting Management — Creates, retrieves, updates, and soft-deletes meetings
+
+* Attendee Management — Adds individual or bulk attendees, including non-employee profiles auto-created as sponsored guests of "Meeting Traveler" type
+
+* Non-Employee Attendee Authentication — Generates OTP-based login URLs enabling sponsored guests to authenticate directly into the Concur booking flow
+
+* Travel Discount Management — Attaches negotiated airline discounts to a meeting
+
+* Meeting Match — Configures a date window to automatically associate attendee travel bookings to the correct meeting
+
+* Audit History — Retrieves a paginated audit trail of all changes to a meeting and its entities
+
+* Third-Party Integration — Links meetings to the partner's own system via `partnerMeetingId`
+
+**Configuration / Feature Activation**
+
+The Meetings API is available to third-party partners using Company-level OAuth 2.0 JWT tokens with `meetings.read` and `meetings.write` scopes.
+
 ### Preview: Detokenizer v5 – Get Banking Info API
 
 The Detokenizer v5 API will include a new endpoint to retrieve bank account details:
@@ -63,7 +87,6 @@ In general, this table lists items that will be shipping in the next 30-60 days.
 
 Date|API|Preview
 ---|---|---
-[06/2026](/tools-support/release-notes/api/2026-06-03.html)|Meetings API|The Meetings API will provide customers and partners with a seamless way to create, manage, and integrate meetings within SAP Concur, supporting meetings created in Concur and third-party platforms.
 [06/2026](/tools-support/release-notes/api/2026-06-03.html)|Trips v5 API with Configurable Trip Event Subscriptions|The Trips v5 API will provide a scalable and performant way to retrieve trip data based on a configurable event-based subscription model, with divisional view support for TMC partners.
 [01/2026](/tools-support/release-notes/api/2026-01-12.html)|Additions to Reservation and Search Requests in Hotel Service v4|This API will add travel arranger details to a reservation request. It will also add the GIATA ID to a hotel search request.
 [07/2025](/tools-support/release-notes/api/2025-07-10.html)|New Attributes for Spend User v4.1|The Spend User v4.1 API will allow you to access the `processorReportAccess` field in the User Preference extension and the User extension will allow you to access the following fields: `officeLocationCountry`, `officeLocationStateProvince`, `officeLocationCity`.


### PR DESCRIPTION
## Summary

- Adds `meetings.read` and `meetings.write` scopes to the App Center Learn More scopes table (alphabetical position between `MEDIC` and `NOTIF`)
- Removes Meetings API entry from the August 2026 Release Notes Previews table
- Adds `### Now Available: Meetings API` to August 2026 RN "New This Month" with present-tense copy
- Replaces `Meetings.oas3.json` with the merged version from [developer/swagger PR #225](https://github.concur.com/developer/swagger/pull/225) (updated `info.title`, `x-sap-shortText`, and `info.description`)
- Removes `{% include prerelease.html %}` banner from the Meetings api-explorer page

## Test plan

- [ ] Verify `meetings.read` and `meetings.write` appear correctly in the scopes table between `MEDIC` and `NOTIF`
- [ ] Verify August 2026 RN shows "Now Available: Meetings API" in "New This Month" and no Meetings entry in Previews
- [ ] Verify api-explorer Meetings page renders without prerelease banner and with updated title/description