### PR TITLE
docs(FINS-14961, FINS-19257): add clearingDate accepted formats and JSON field-ordering guidance

### DIFF
--- a/src/api-reference/financial-integration/v4.financial-documents-schema.markdown
+++ b/src/api-reference/financial-integration/v4.financial-documents-schema.markdown
@@ -5,6 +5,8 @@ layout: reference
 
 # Financial Documents Schemas
 
+> **Note:** In accordance with [RFC 8259](https://tools.ietf.org/html/rfc8259), the order of fields within JSON objects returned by FIS APIs is not guaranteed and is not part of the API contract. This applies to all FIS document types (expense, invoice, cash advance, payroll, request obligation, and report obligation). Consumers must deserialize and process JSON payloads using property names and must not rely on field position or serialization order. Any dependency on field ordering is outside the supported integration contract and may result in failures when valid service changes are introduced.
+
 ## Expense <a name="scexpense"></a>
 
 ### <a name="scexpemploy"></a>Expense - Employee

--- a/src/api-reference/financial-integration/v4.financial-integration.markdown
+++ b/src/api-reference/financial-integration/v4.financial-integration.markdown
@@ -21,6 +21,10 @@ Below are some benefits for using the Financial Integration service:
 
 Standard customers should reach out to their SAP Concur representative to receive more information on implementation. Access to this documentation does not provide access to the API. The API is available in North America, and EMEA, Production and Implementation environments.
 
+## <a name="json-field-ordering"></a>JSON Object Field Ordering
+
+In accordance with [RFC 8259](https://tools.ietf.org/html/rfc8259), the order of fields within JSON objects returned by FIS APIs is not guaranteed and is not part of the API contract. Consumers must deserialize and process JSON payloads using property names and must not rely on field position or serialization order. Any dependency on field ordering is outside the supported integration contract and may result in failures when valid service changes are introduced. This applies to all FIS document types and to all GET and POST JSON payloads.
+
 ## <a name="products-editions"></a>Products and Editions
 
 * Concur Expense Professional Edition
@@ -796,7 +800,7 @@ Name|Type|Format|Description
 
 Name|Type|Format|Description
 ---|---|---|---
-`clearingDate`|`string`|-|Date the payment cleared.
+`clearingDate`|`string`|`yyyy-MM-dd'T'HH:mm:ss.SSS'Z'` or `yyyyMMdd`|Date the payment cleared. Only the following two date formats are accepted: `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'` (for example, `2019-02-06T12:00:00.000Z`) or `yyyyMMdd` (for example, `20190206`). Any other format may cause the date to display incorrectly in the Report Payments UI.
 `clearingAmount`|`double`|-|Amount cleared.
 `clearingCurrency`|`string`|-|Currency value.
 `receiver`|`array`|[Receiver Details](#schema-receiver)|Receiver details.

--- a/src/api-reference/financial-integration/v4.funds-reservation-schema.markdown
+++ b/src/api-reference/financial-integration/v4.funds-reservation-schema.markdown
@@ -7,6 +7,8 @@ layout: reference
 
 {% include prerelease.html %}
 
+> **Note:** In accordance with [RFC 8259](https://tools.ietf.org/html/rfc8259), the order of fields within JSON objects returned by FIS APIs is not guaranteed and is not part of the API contract. Consumers must deserialize and process JSON payloads using property names and must not rely on field position or serialization order. Any dependency on field ordering is outside the supported integration contract and may result in failures when valid service changes are introduced.
+
 # <a name="scobligation"></a>Obligation/Funds Reservation
 
 ## <a name="screquestobligation"></a>Request Obligation


### PR DESCRIPTION
FINS-14961: document the two accepted clearingDate formats (yyyy-MM-dd'T'HH:mm:ss.SSS'Z' and yyyyMMdd) for the FIS Payment Confirmation request, per EMT requirement.

FINS-19257: add RFC 8259 guidance that JSON object field ordering is not guaranteed and not part of the API contract, on the FIS getting started, financial documents schema, and funds reservation schema pages.

