### PR TITLE
docs(meetings): minor doc corrections post-merge

### DIFF
--- a/src/api-reference/travel/meetings-v4/v4.meetings-endpoints.markdown
+++ b/src/api-reference/travel/meetings-v4/v4.meetings-endpoints.markdown
@@ -9,8 +9,6 @@ Endpoints and schemas for creating and managing meetings and attendees within th
 
 All meeting-scoped endpoints accept an optional `companyId` query parameter (UUID). When omitted, the company is resolved from the token; when supplied it must match the token's company.
 
-Find integration details in the [Meetings Integration Guide](/api-guides/meetings/meetings-integration-guide.html).
-
 ## <a name="list-meetings"></a>List Meetings
 
 Retrieves meetings for the caller's company.

--- a/src/api-reference/travel/meetings-v4/v4.meetings-get-started.markdown
+++ b/src/api-reference/travel/meetings-v4/v4.meetings-get-started.markdown
@@ -7,6 +7,8 @@ layout: reference
 
 With the Meetings API, you can create and manage meetings and their attendees within Concur Travel. It supports two primary use cases: meetings created natively within the SAP Concur platform using the Meetings Admin UI or Joule, and meetings created by external partners through API integration.
 
+Find integration details in the [Meetings Integration Guide](/api-guides/meetings/meetings-integration-guide.html).
+
 ## <a name="limitations"></a>Limitations
 
 Access to this documentation does not provide access to the API.


### PR DESCRIPTION
## Summary

- Move integration guide link from endpoints page to get-started page (second paragraph)
- Remove marketing language ("seamless") and fix branding in August and June 2026 RNs
- Restore "third-party meetings" distinction in RN descriptions
- Add `# Meetings v4` heading to get-started page
- Add `# Meetings v4 - Endpoints` heading to endpoints page
- Update integration guide intro: remove parentheses, use "such as", rewrite prereqs as Note
- Fix relative link in integration guide
- Remove bold from "Meetings API" and fix capitalisation in section heading

## Test plan

- [ ] Verify get-started page renders with correct heading and integration guide link
- [ ] Verify endpoints page renders without integration guide link
- [ ] Verify August and June 2026 RNs show corrected descriptions