### PR TITLE
docs(meetings): remove Meetings from API Explorer

### DIFF
--- a/src/_data/sidebars/api-explorer.yml
+++ b/src/_data/sidebars/api-explorer.yml
@@ -110,8 +110,6 @@
         url: https://api.sap.com/api/ConcurExpenseListItems/overview
       - title: List Item Bulk
         url: https://api.sap.com/api/ConcurListItemBulk/overview
-      - title: Meetings
-        url: /api-explorer/v4-0/Meetings.html
       - title: Purchase Requests
         url: https://api.sap.com/api/ConcurInvoicePurchaseRequest/overview
       - title: Quick Expenses


### PR DESCRIPTION
## Summary

- Remove Meetings entry from the API Explorer sidebar
- Meetings documentation is available in the API reference pages