### PR TITLE
docs(release-notes): add ESS webhook SSL certificate renewal preview

### DIFF
--- a/src/tools-support/release-notes/api/2026-08-06.md
+++ b/src/tools-support/release-notes/api/2026-08-06.md
@@ -6,6 +6,13 @@ layout: reference
 
 ## New This Month
 
+### Preview: New Client SSL Certificate for ESS webhook.api.concursolutions.com
+
+In an effort to ensure the ongoing security of our products and services, on September 24, 2026, ESS will be issuing a new webhook.api.concursolutions.com SSL certificate. We will always use the same client [x509](/api-reference/ess/2026.webhook.api.concursolutions.com.pem) certificate with the following subject: C=DE, ST=Baden-Württemberg, L=Walldorf, O=SAP SE, CN=webhook.api.concursolutions.com.
+
+All details will be published in the [Event Subscription Service v4](/api-reference/ess/v4.event-subscription.html) documentation soon.
+
+
 ### Now Available: Meetings API
 
 The Meetings API enables customers and partners to create, manage, and integrate meetings within the SAP Concur platform. It supports meetings created directly within Concur Travel via the Meetings Admin UI, as well as third-party meetings originating from a partner's platform — where the API keeps both systems in sync.


### PR DESCRIPTION
## Summary
- Adds Preview section to August 2026 release notes for the ESS webhook.api.concursolutions.com SSL certificate renewal scheduled for September 24, 2026
- References the existing .pem certificate already in `src/api-reference/ess/`

## Notes
The `.pem` file in `src/tools-support/release-notes/api/` was NOT included — the certificate is already in the correct location (`src/api-reference/ess/`) and the RN link points there correctly.