### PR TITLE
docs(release-notes): add September 2026 API release notes

### DIFF
--- a/src/_data/sidebars/tools-support.yml
+++ b/src/_data/sidebars/tools-support.yml
@@ -5,6 +5,8 @@
 - title: Developer Platform Release Notes
   url: ''
   children:
+      - title: September 2026
+        url: /tools-support/release-notes/api/2026-09-04.html
       - title: August 2026
         url: /tools-support/release-notes/api/2026-08-06.html
       - title: July 2026

--- a/src/tools-support/release-notes/api/2026-09-04.md
+++ b/src/tools-support/release-notes/api/2026-09-04.md
@@ -26,8 +26,6 @@ A new field has been added to the Hotel Service v4 reservation request that allo
   ]
 ```
 
-![Hotel Service v4 traveler title field](./2026-09-04-hotel-service.png)
-
 ## Ongoing
 
 ### Important! Upcoming Shutdown of Request V1, V3, and V3.1

--- a/src/tools-support/release-notes/api/2026-09-04.md
+++ b/src/tools-support/release-notes/api/2026-09-04.md
@@ -1,0 +1,70 @@
+---
+title: SAP Concur Developer Center - API Release Notes, September 2026
+layout: reference
+---
+# API Release Notes, September 2026
+
+## New This Month
+
+### Now Available: Hotel Service v4 — Traveler Title Field
+
+A new field has been added to the Hotel Service v4 reservation request that allows the traveler's title to be sent when present in their profile. The new field is part of the `guests` array:
+
+```json
+"guests": [
+    {
+      "firstname": "Blake",
+      "middleName": "Jordan",
+      "lastname": "Smith",
+      "title": "Mister",
+      "address": {
+        "addressLines": [
+          "910 Mainland Street"
+        ]
+      }
+    }
+  ]
+```
+
+![Hotel Service v4 traveler title field](./2026-09-04-hotel-service.png)
+
+## Ongoing
+
+### Important! Upcoming Shutdown of Request V1, V3, and V3.1
+
+**Updated Effective Date: November 3, 2026**
+
+As previously announced, the Concur Request APIs v1.0, v3.0, and v3.1 have been decommissioned. These versions will be retired and no longer accessible as of November 3, 2026. Customers currently using these versions must migrate to the successor API, Request API V4, to ensure uninterrupted functionality. Please reach out to your Concur representative for more information.
+
+## Previews
+
+In general, this table lists items that will be shipping in the next 30-60 days. For a broader view of features that are coming, please see our [Road Map Explorer](https://roadmaps.sap.com/board?PRODUCT=089E017A62AB1EDA94C15F5EDB3400E1&range=CURRENT-LAST#Q3%202024).
+
+Date|API|Preview
+---|---|---
+[08/2026](/tools-support/release-notes/api/2026-08-06.html)|Detokenizer v5 – Get Banking Info API|The Detokenizer v5 API will include a new endpoint to retrieve bank account details: `POST /detokenizer/v5/bankaccounts/{loginId}`. This endpoint returns the most recently modified active bank account for the given employee `loginId`, with sensitive fields decrypted and the full payload re-encrypted with the caller's AES symmetric key.
+[06/2026](/tools-support/release-notes/api/2026-06-03.html)|Trips v5 API with Configurable Trip Event Subscriptions|The Trips v5 API will provide a scalable and performant way to retrieve trip data based on a configurable event-based subscription model, with divisional view support for TMC partners.
+[01/2026](/tools-support/release-notes/api/2026-01-12.html)|Additions to Reservation and Search Requests in Hotel Service v4|This API will add travel arranger details to a reservation request. It will also add the GIATA ID to a hotel search request.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|New Attributes for Spend User v4.1|The Spend User v4.1 API will allow you to access the `processorReportAccess` field in the User Preference extension and the User extension will allow you to access the following fields: `officeLocationCountry`, `officeLocationStateProvince`, `officeLocationCity`.
+[04/2025](/tools-support/release-notes/api/2025-04-03.html)|New Fields Added to Financial Integration Services (FIS) v4 API|For customers of the Concur Expense Professional Edition using the Financial Integration Services (FIS) v4 API, additional fields will be included in the Expense report document payload and mileage fields will be added to the payroll document schema.
+[05/2024](/tools-support/release-notes/api/archive/2024-05-09.html)|Retention Period for Credit Card Data Files|For compliance reasons, SAP Concur will be implementing a process wherein card data files received from external sources (Issuing banks, Card associations) will be deleted from systems after 90 days.
+[01/2024](/tools-support/release-notes/api/archive/2024-01-11.html)|Hotel Service v4|Updates to Hotel Service v4 that will remove existing elements from the <Profiles> section relating to gender and name prefixes.
+
+## Deprecations and Decommissions
+
+APIs are being deprecated or decommissioned in accordance with the [SAP Concur API Lifecycle & Deprecation Policy](/tools-support/deprecation-policy.html).
+
+Date|API|Details
+---|---|---
+[06/2026](/tools-support/release-notes/api/2026-06-03.html)|Decommission of Launch External URL V1|Effective June 23, 2026, the Launch External URL V1 callout API was decommissioned. Customers must migrate to Launch External URL V4, which provides full functional equivalence with no known gaps.
+[06/2026](/tools-support/release-notes/api/2026-06-03.html)|Deprecation of Company Cards Transactions v1|Effective June 8, 2026, the Company Cards Transactions v1 API was deprecated. This has been replaced by Cards v4 API. Decommission will follow.
+[10/2025](/tools-support/release-notes/api/2025-10-02.html)|Deprecation of Locations v3|Effective October 10, 2025, the Locations v3 API will be deprecated. This has been replaced by Localities v5. Decommission will follow.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|Deprecation of Expense Group Configurations v3|Effective June 26, 2025, the Expense Group Configurations v3 API was deprecated. This has been replaced by the Expense Configuration v4 API. Decommission will follow.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|Deprecation of Expense v3 DELETE|Effective June 26, 2025, Expense v3 DELETE was deprecated. This has been replaced by Expense v4 Delete. Decommission will follow.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|Deprecation of Attendees v3 API|Effective July 1, 2025, the Attendees v3 API was deprecated. This has been replaced by Attendees v4. Decommission will follow.
+[07/2025](/tools-support/release-notes/api/2025-07-10.html)|Deprecation of Attendee Types v3 API|Effective July 1, 2025, the Attendee Types v3 API was deprecated. This has been replaced by Attendee Types v4. Decommission will follow.
+[04/2025](/tools-support/release-notes/api/2025-04-03.html)|Deprecation of Attendees v1, v1.1, and v2|Effective October 9, 2018, we have deprecated the Attendees v1, v1.1, and v2 APIs. Decommission will follow.
+[03/2024](/tools-support/release-notes/api/archive/2024-03-14.html)|Deprecation of Spend User Retrieval 4.0.|The decommission of password provisioning via file import will occur in April 2025.
+[01/2023](/tools-support/release-notes/api/archive/2023-01-05.html)|Move from the Travel Request External Validation Callout v1 to the Event Subscription Service (ESS)|This callout was designed to work with the Concur Request v1 API that is in the process of being decommissioned. Users are strongly recommended to move to the Event Subscription Services (ESS) in order to subscribe to the [Request events](https://developer.concur.com/api-reference/ess/v4.event-subscription.html).
+[01/2021](/tools-support/release-notes/api/archive/2021-01-22.html#planned-list-deprecation)|List v3 API|Effective April 16, 2021, we have deprecated the List v3 API. This API is replaced by the [List v4](/api-reference/common/lists/v4.list.html) API. List v3 is planned to be retired in a future release.
+[01/2021](/tools-support/release-notes/api/archive/2021-01-22.html#planned-list-item-deprecation)|List Item v3 API|Effective April 16, 2021, we have deprecated the List Item v3 API. This API is replaced by the [List Item v4](/api-reference/common/list-item/v4.list-item.html) API. List Item v3 is planned to be retired in a future release. Please migrate to the [List Item v4](/api-reference/common/list-item/v4.list-item.html) API as soon as possible.

--- a/src/tools-support/release-notes/api/2026-09-04.md
+++ b/src/tools-support/release-notes/api/2026-09-04.md
@@ -28,6 +28,12 @@ A new field has been added to the Hotel Service v4 reservation request that allo
 
 ## Ongoing
 
+### New Client SSL Certificate for ESS webhook.api.concursolutions.com
+
+In an effort to ensure the ongoing security of our products and services, on September 24, 2026, ESS will be issuing a new webhook.api.concursolutions.com SSL certificate. We will always use the same client [x509](/api-reference/ess/2026.webhook.api.concursolutions.com.pem) certificate with the following subject: C=DE, ST=Baden-Württemberg, L=Walldorf, O=SAP SE, CN=webhook.api.concursolutions.com.
+
+All details will be published in the [Event Subscription Service v4](/api-reference/ess/v4.event-subscription.html) documentation soon.
+
 ### Important! Upcoming Shutdown of Request V1, V3, and V3.1
 
 **Updated Effective Date: November 3, 2026**

--- a/src/tools-support/release-notes/index.markdown
+++ b/src/tools-support/release-notes/index.markdown
@@ -6,6 +6,7 @@ layout: reference
 
 ## Developer Platform Release Notes
 
+* [September 2026](./api/2026-09-04.html)
 * [August 2026](./api/2026-08-06.html)
 * [July 2026](./api/2026-07-01.html)
 * [June 2026](./api/2026-06-03.html)


### PR DESCRIPTION
## Summary

- **Now Available**: Hotel Service v4 — new `title` field in the `guests` array of the reservation request, sent when present in the traveler's profile
- **Moved to Ongoing**: Request V1/V3/V3.1 shutdown notice (effective November 3, 2026); ESS webhook SSL certificate renewal (effective September 24, 2026)
- **Moved to Previews table**: Detokenizer v5 – Get Banking Info API
- **Removed from Ongoing**: August SSL certificate renewal notices (implementation dates passed)
- **Updated**: `index.markdown` and `tools-support.yml` with September 2026 entry