### PR TITLE
docs(legal): add terms of use 2026 and update footer link

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -8,7 +8,7 @@
       </script>
       All Rights Reserved.
       <a href="https://www.concur.com/en-us/privacy-policy">Privacy Policy</a> |
-      <a href="{{ site.baseurl }}/terms-of-use-2021.html">Terms of Use</a> |
+      <a href="{{ site.baseurl }}/terms-of-use-2026.html">Terms of Use</a> |
       <a href="https://help.sap.com/doc/sap-api-policy/">SAP API Policy</a> |
       <a href="{{ site.baseurl }}/tools-support/deprecation-policy.html">API Deprecation Policy</a> |
       <a href="{{ site.baseurl }}/legal-disclosure.html">Legal Disclosure</a> |

--- a/src/terms-of-use-2026.markdown
+++ b/src/terms-of-use-2026.markdown
@@ -1,0 +1,16 @@
+---
+title: Terms of Use
+layout: reference
+---
+
+<!-- Print button -->
+<a class="btn btn-primary pull-right hidden-print" href="javascript:window.print()">
+  <span class="fas fa-print" aria-hidden="true"></span>
+  Print
+</a>
+
+## **Terms of use for SAP Concur websites**
+
+**Revised and posted as of September 3, 2026**
+
+This website is governed by the Terms of Use for SAP Websites available at [[Terms of Use for SAP Websites | About SAP](https://www.sap.com/about/legal/terms-of-use.html)] (the "SAP Website Terms"), except that the SAP Store Appendix and any other website-specific appendices not expressly applicable to this website are excluded. Concur Technologies, Inc., established under the laws of Delaware, with business address at 601 108th Ave NE, Suite 1000, Bellevue, Washington, is an Affiliate of SAP SE for purposes of the SAP Website Terms, and references to SAP Website or SAP Materials shall be deemed to mean SAP Concur Website and SAP Concur Materials.


### PR DESCRIPTION
## Summary

- Added `src/terms-of-use-2026.markdown` replacing the 2021 version with updated text referencing the SAP Website Terms
- Updated footer link from `terms-of-use-2021.html` to `terms-of-use-2026.html`
- The 2021 file remains in the repository but is no longer linked